### PR TITLE
Add resource-driven data extensions and save versioning

### DIFF
--- a/frontend/src/components/ActionMenu.tsx
+++ b/frontend/src/components/ActionMenu.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import type { JSX } from 'react'
 import { Lightning, Coins, Scroll, Sword, UsersThree, ShieldCheck, ArrowsCounterClockwise, Handshake, Target, Eye, Barricade } from '@phosphor-icons/react'
 import type { ActionType } from '../game/types'
 import { ACTION_LABELS } from '../game/constants'

--- a/frontend/src/components/HUD.tsx
+++ b/frontend/src/components/HUD.tsx
@@ -9,7 +9,7 @@ interface HUDProps {
   actionsRemaining: number
 }
 
-const statConfig = [
+const statConfig: Array<{ key: keyof NationState['stats']; label: string; invert?: boolean }> = [
   { key: 'stability', label: 'Stability' },
   { key: 'military', label: 'Military' },
   { key: 'tech', label: 'Technology' },
@@ -19,7 +19,7 @@ const statConfig = [
   { key: 'support', label: 'Support' },
   { key: 'science', label: 'Science' },
   { key: 'laws', label: 'Laws' },
-] as const
+]
 
 const toneFor = (value: number, invert?: boolean) => {
   if (invert) {
@@ -51,7 +51,7 @@ export const HUD = ({ nation, treasury, turn, actionsRemaining }: HUDProps) => (
           key={stat.key}
           label={stat.label}
           value={nation.stats[stat.key]}
-          tone={toneFor(nation.stats[stat.key], stat.invert) as any}
+          tone={toneFor(nation.stats[stat.key], stat.invert)}
         />
       ))}
     </div>

--- a/frontend/src/config/config.json
+++ b/frontend/src/config/config.json
@@ -21,5 +21,11 @@
   "baseScienceDrift": 1,
   "baseCrimeGrowth": 1,
   "eventStabilityVariance": 3,
-  "eventEconomyVariance": 4
+  "eventEconomyVariance": 4,
+  "defaultUnitSupply": 5,
+  "supplyConsumptionPerTurn": 1,
+  "fortificationDefenseBonus": 2,
+  "missionRefreshInterval": 5,
+  "traditionAdoptionCost": 8,
+  "resourceShortagePenalty": 3
 }

--- a/frontend/src/data/missions.json
+++ b/frontend/src/data/missions.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "mission_secure_plateau",
+    "name": "Secure the Plateau",
+    "description": "Fortify the eastern frontier and ensure horse herds thrive.",
+    "rewards": ["+5 stability", "+20 grain stockpile"],
+    "requirements": ["Control medes_plateau", "Supply cache in frontier >= 6"],
+    "expiresIn": 12
+  },
+  {
+    "id": "mission_consult_oracle",
+    "name": "Consult the Oracle",
+    "description": "Hold a grand divination to guide the dynasty's next campaign.",
+    "rewards": ["+4 influence", "Reveal random tech"],
+    "requirements": ["Stability >= 70", "At least 2 characters with loyalty >= 70"],
+    "expiresIn": 10
+  },
+  {
+    "id": "mission_expand_canals",
+    "name": "Expand the Canal Grid",
+    "description": "Finance new sluices to boost flood control and trade.",
+    "rewards": ["+2 development in all river territories", "+10 luxuries"],
+    "requirements": ["Control harappa_indus", "Treasury >= 20"],
+    "expiresIn": 14
+  },
+  {
+    "id": "mission_build_ziggurat",
+    "name": "Raise a Monument",
+    "description": "Commission a towering ziggurat to awe allies and rivals.",
+    "rewards": ["+6 influence", "Unlock festival tradition"],
+    "requirements": ["Control akkad_mesopotamia", "At least 8 stone resources"],
+    "expiresIn": 16
+  },
+  {
+    "id": "mission_crush_rebels",
+    "name": "Crush the Rebels",
+    "description": "Suppress unrest before it spreads through the realm.",
+    "rewards": ["Crime -6", "Supply caches refreshed"],
+    "requirements": ["No territory unrest above 30", "At least one fortification level 2"],
+    "expiresIn": 8
+  },
+  {
+    "id": "mission_dominate_sea",
+    "name": "Dominate the Sea",
+    "description": "Reassert control over the central sea lanes and harbors.",
+    "rewards": ["+5 economy", "Gain Naval Marines"],
+    "requirements": ["Control 3 coastal territories", "Maintain 2 naval units"],
+    "expiresIn": 12
+  },
+  {
+    "id": "mission_raid_frontier",
+    "name": "Raid the Frontier",
+    "description": "Launch raids into settled lands to capture tribute.",
+    "rewards": ["+10 horses", "Relations -5 with raided nation"],
+    "requirements": ["At war with a settled nation", "At least one cavalry unit with supply >= 5"],
+    "expiresIn": 6
+  },
+  {
+    "id": "mission_honour_nile",
+    "name": "Honour the Nile",
+    "description": "Celebrate the inundation to secure loyalty and abundance.",
+    "rewards": ["+6 stability", "+10 luxuries"],
+    "requirements": ["Control egypt_delta", "Grain stockpile >= 15"],
+    "expiresIn": 10
+  },
+  {
+    "id": "mission_expand_republic",
+    "name": "Expand the Republic",
+    "description": "Integrate new allies and extend citizen rights.",
+    "rewards": ["+4 influence", "Unlock new tradition"],
+    "requirements": ["Control 5 territories", "Support >= 65"],
+    "expiresIn": 14
+  },
+  {
+    "id": "mission_reopen_trade",
+    "name": "Reopen Trade",
+    "description": "Restore the prestige of the island trade leagues.",
+    "rewards": ["+5 economy", "Gain 5 luxuries"],
+    "requirements": ["Have an alliance with a coastal nation", "Treasury >= 18"],
+    "expiresIn": 12
+  },
+  {
+    "id": "mission_codify_laws",
+    "name": "Codify the Laws",
+    "description": "Gather scribes to record treaties and statutes for posterity.",
+    "rewards": ["+5 laws", "Tradition adoption cost -2"],
+    "requirements": ["Laws >= 65", "Control hittites_capital"],
+    "expiresIn": 15
+  }
+]

--- a/frontend/src/data/nations.json
+++ b/frontend/src/data/nations.json
@@ -3,7 +3,11 @@
     "id": "medes",
     "name": "Medes",
     "description": "Highland coalition famed for swift horse archers and vigilant satraps guarding the Iranian plateau.",
-    "territories": ["medes_caspian", "medes_plateau", "medes_frontier"],
+    "territories": [
+      "medes_caspian",
+      "medes_plateau",
+      "medes_frontier"
+    ],
     "stats": {
       "stability": 68,
       "military": 74,
@@ -22,13 +26,97 @@
     "disadvantages": [
       "Fragmented Nobility: -5 stability if economy falls below 50.",
       "Mountain Supply: Army recruitment costs +1 upkeep."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 10
+      },
+      {
+        "type": "horses",
+        "amount": 6
+      },
+      {
+        "type": "timber",
+        "amount": 4
+      }
+    ],
+    "characters": [
+      {
+        "id": "medes_deioces",
+        "name": "Deioces",
+        "role": "ruler",
+        "loyalty": 78,
+        "traits": [
+          "Arbiter of Tribes",
+          "Visionary Planner"
+        ]
+      },
+      {
+        "id": "medes_phraortes",
+        "name": "Phraortes",
+        "role": "general",
+        "loyalty": 66,
+        "traits": [
+          "Horse Lord",
+          "Frontier Vigilance"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "medes_clans",
+        "name": "Highland Clans",
+        "agenda": "Protect grazing rights on the plateau",
+        "approval": 58,
+        "influence": 55,
+        "leaderId": "medes_deioces"
+      },
+      {
+        "id": "medes_satraps",
+        "name": "Satrap Coalition",
+        "agenda": "Expand fortifications along the frontier",
+        "approval": 64,
+        "influence": 60,
+        "leaderId": "medes_phraortes"
+      }
+    ],
+    "traditions": [
+      "tradition_mede_horsemasters",
+      "tradition_mede_watchfires"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "horse_archers",
+        "territoryId": "medes_frontier",
+        "strength": 7
+      },
+      {
+        "unitId": "levy_infantry",
+        "territoryId": "medes_plateau",
+        "strength": 6
+      }
+    ],
+    "startingTechs": [
+      "tech_horse_domestication"
+    ],
+    "startingMissions": [
+      "mission_secure_plateau"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "median_rise"
+    ],
+    "startingTreasury": 22
   },
   {
     "id": "shang",
     "name": "Shang",
     "description": "Bronze-age dynasty mastering divination and chariot warfare across the Yellow River basin.",
-    "territories": ["shang_yellow", "shang_delta"],
+    "territories": [
+      "shang_yellow",
+      "shang_delta"
+    ],
     "stats": {
       "stability": 72,
       "military": 70,
@@ -47,13 +135,98 @@
     "disadvantages": [
       "Ancestor Burdens: -5 support if laws fall under 55.",
       "Flood Risk: Delta territories suffer +1 crime per drought event."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 12
+      },
+      {
+        "type": "bronze",
+        "amount": 8
+      },
+      {
+        "type": "luxuries",
+        "amount": 5
+      }
+    ],
+    "characters": [
+      {
+        "id": "shang_wuding",
+        "name": "Wu Ding",
+        "role": "ruler",
+        "loyalty": 82,
+        "traits": [
+          "Oracle Seeker",
+          "Bronze Patron"
+        ]
+      },
+      {
+        "id": "shang_fuhao",
+        "name": "Fu Hao",
+        "role": "general",
+        "loyalty": 75,
+        "traits": [
+          "Battle Priestess",
+          "Chariot Commander"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "shang_oracle",
+        "name": "Diviners of Anyang",
+        "agenda": "Consult the ancestors for every major decision",
+        "approval": 68,
+        "influence": 72,
+        "leaderId": "shang_wuding"
+      },
+      {
+        "id": "shang_chariots",
+        "name": "Chariot Marshals",
+        "agenda": "Expand bronze foundries for elite troops",
+        "approval": 61,
+        "influence": 63,
+        "leaderId": "shang_fuhao"
+      }
+    ],
+    "traditions": [
+      "tradition_shang_divinations",
+      "tradition_shang_chariotry"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "war_chariots",
+        "territoryId": "shang_delta",
+        "strength": 8
+      },
+      {
+        "unitId": "bronze_spearmen",
+        "territoryId": "shang_yellow",
+        "strength": 7
+      }
+    ],
+    "startingTechs": [
+      "tech_ritual_divination"
+    ],
+    "startingMissions": [
+      "mission_consult_oracle"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "oracle_dynasty"
+    ],
+    "startingTreasury": 24
   },
   {
     "id": "harappa",
     "name": "Harappa",
     "description": "Indus valley planners balancing trade guilds and elaborate irrigation networks.",
-    "territories": ["harappa_indus", "harappa_meluha", "harappa_sindh"],
+    "territories": [
+      "harappa_indus",
+      "harappa_meluha",
+      "harappa_sindh"
+    ],
     "stats": {
       "stability": 75,
       "military": 54,
@@ -72,13 +245,97 @@
     "disadvantages": [
       "Pacifist Merchants: -10 military if stability drops under 55.",
       "Monsoon Fragility: Drought events reduce economy by extra 2."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 14
+      },
+      {
+        "type": "stone",
+        "amount": 6
+      },
+      {
+        "type": "luxuries",
+        "amount": 7
+      }
+    ],
+    "characters": [
+      {
+        "id": "harappa_rishi",
+        "name": "Priest Rishi",
+        "role": "sage",
+        "loyalty": 73,
+        "traits": [
+          "Canal Scholar",
+          "Seal Keeper"
+        ]
+      },
+      {
+        "id": "harappa_shakti",
+        "name": "Shakti of Meluha",
+        "role": "governor",
+        "loyalty": 70,
+        "traits": [
+          "Harbor Master",
+          "Guild Liaison"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "harappa_guilds",
+        "name": "Meluha Guild Confederation",
+        "agenda": "Secure trade monopolies with far ports",
+        "approval": 72,
+        "influence": 68,
+        "leaderId": "harappa_shakti"
+      },
+      {
+        "id": "harappa_priests",
+        "name": "Great Bath Custodians",
+        "agenda": "Maintain ritual purity and canal upkeep",
+        "approval": 65,
+        "influence": 60,
+        "leaderId": "harappa_rishi"
+      }
+    ],
+    "traditions": [
+      "tradition_harappa_canalmasters",
+      "tradition_harappa_sealmakers"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "levy_infantry",
+        "territoryId": "harappa_indus",
+        "strength": 6
+      },
+      {
+        "unitId": "naval_marines",
+        "territoryId": "harappa_meluha",
+        "strength": 6
+      }
+    ],
+    "startingTechs": [
+      "tech_hydraulic_engineering"
+    ],
+    "startingMissions": [
+      "mission_expand_canals"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "indus_ascendancy"
+    ],
+    "startingTreasury": 26
   },
   {
     "id": "akkad",
     "name": "Akkad",
     "description": "Imperial architects leveraging river trade and siegecraft to dominate Mesopotamia.",
-    "territories": ["akkad_mesopotamia", "akkad_lower"],
+    "territories": [
+      "akkad_mesopotamia",
+      "akkad_lower"
+    ],
     "stats": {
       "stability": 64,
       "military": 76,
@@ -97,13 +354,97 @@
     "disadvantages": [
       "Rebel Cities: Crime penalties doubled on revolt checks.",
       "Harsh Conscription: Recruit Army lowers support by 2."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 11
+      },
+      {
+        "type": "bronze",
+        "amount": 7
+      },
+      {
+        "type": "timber",
+        "amount": 5
+      }
+    ],
+    "characters": [
+      {
+        "id": "akkad_sargon",
+        "name": "Sargon",
+        "role": "ruler",
+        "loyalty": 80,
+        "traits": [
+          "Imperial Architect",
+          "River Trader"
+        ]
+      },
+      {
+        "id": "akkad_enheduanna",
+        "name": "Enheduanna",
+        "role": "sage",
+        "loyalty": 76,
+        "traits": [
+          "Poet Laureate",
+          "Diplomatic Envoy"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "akkad_merchants",
+        "name": "Canal Merchants",
+        "agenda": "Expand trade posts along the rivers",
+        "approval": 63,
+        "influence": 67,
+        "leaderId": "akkad_enheduanna"
+      },
+      {
+        "id": "akkad_legions",
+        "name": "Siege Engineers",
+        "agenda": "Invest in battering rams and sappers",
+        "approval": 60,
+        "influence": 62,
+        "leaderId": "akkad_sargon"
+      }
+    ],
+    "traditions": [
+      "tradition_akkad_ziggurat_builders",
+      "tradition_akkad_siegecraft"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "bronze_spearmen",
+        "territoryId": "akkad_mesopotamia",
+        "strength": 7
+      },
+      {
+        "unitId": "siege_engineers",
+        "territoryId": "akkad_lower",
+        "strength": 5
+      }
+    ],
+    "startingTechs": [
+      "tech_wheel_siege"
+    ],
+    "startingMissions": [
+      "mission_build_ziggurat"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "imperial_dawn"
+    ],
+    "startingTreasury": 25
   },
   {
     "id": "assyria",
     "name": "Assyria",
     "description": "Hardened armies and iron discipline radiating from fortress cities along the Tigris.",
-    "territories": ["assyria_upper", "assyria_heartland"],
+    "territories": [
+      "assyria_upper",
+      "assyria_heartland"
+    ],
     "stats": {
       "stability": 66,
       "military": 82,
@@ -122,13 +463,97 @@
     "disadvantages": [
       "Overextension: Stability -3 for each concurrent war after the first.",
       "Intimidation Diplomacy: Diplomacy Offer effects halved."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 9
+      },
+      {
+        "type": "horses",
+        "amount": 5
+      },
+      {
+        "type": "stone",
+        "amount": 6
+      }
+    ],
+    "characters": [
+      {
+        "id": "assyria_ashur",
+        "name": "Ashur-Nasir",
+        "role": "ruler",
+        "loyalty": 74,
+        "traits": [
+          "Fortress Builder",
+          "Iron Discipline"
+        ]
+      },
+      {
+        "id": "assyria_shamshi",
+        "name": "Shamshi Belu",
+        "role": "general",
+        "loyalty": 69,
+        "traits": [
+          "Siege Veteran",
+          "Relentless Scout"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "assyria_officers",
+        "name": "Royal Officers",
+        "agenda": "Maintain high readiness along Tigris forts",
+        "approval": 62,
+        "influence": 66,
+        "leaderId": "assyria_shamshi"
+      },
+      {
+        "id": "assyria_merchants",
+        "name": "Assur Traders",
+        "agenda": "Secure caravan tolls to fund the army",
+        "approval": 58,
+        "influence": 59,
+        "leaderId": "assyria_ashur"
+      }
+    ],
+    "traditions": [
+      "tradition_assyria_fortified_path",
+      "tradition_assyria_iron_ranks"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "bronze_spearmen",
+        "territoryId": "assyria_heartland",
+        "strength": 7
+      },
+      {
+        "unitId": "horse_archers",
+        "territoryId": "assyria_upper",
+        "strength": 7
+      }
+    ],
+    "startingTechs": [
+      "tech_iron_forging"
+    ],
+    "startingMissions": [
+      "mission_crush_rebels"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "fortress_empire"
+    ],
+    "startingTreasury": 23
   },
   {
     "id": "carthage",
     "name": "Carthage",
     "description": "Thalassocratic traders balancing mercenary hosts and far-flung harbors.",
-    "territories": ["carthage_carthage", "carthage_maghrib"],
+    "territories": [
+      "carthage_carthage",
+      "carthage_maghrib"
+    ],
     "stats": {
       "stability": 70,
       "military": 68,
@@ -147,13 +572,98 @@
     "disadvantages": [
       "Senatorial Gridlock: Passing laws requires stability >=60 or fails.",
       "Mercenary Loyalty: Lose 3 stability if military falls under 55."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 8
+      },
+      {
+        "type": "timber",
+        "amount": 7
+      },
+      {
+        "type": "luxuries",
+        "amount": 9
+      }
+    ],
+    "characters": [
+      {
+        "id": "carthage_dido",
+        "name": "Queen Dido",
+        "role": "ruler",
+        "loyalty": 85,
+        "traits": [
+          "Sea Founder",
+          "Merchant Matron"
+        ]
+      },
+      {
+        "id": "carthage_hanno",
+        "name": "Hanno the Navigator",
+        "role": "diplomat",
+        "loyalty": 72,
+        "traits": [
+          "Explorer Admiral",
+          "Silver Tongue"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "carthage_senate",
+        "name": "Merchant Senate",
+        "agenda": "Expand sea trade routes and colonies",
+        "approval": 70,
+        "influence": 75,
+        "leaderId": "carthage_dido"
+      },
+      {
+        "id": "carthage_marines",
+        "name": "Sacred Band Captains",
+        "agenda": "Invest in elite marines and harbor walls",
+        "approval": 63,
+        "influence": 65,
+        "leaderId": "carthage_hanno"
+      }
+    ],
+    "traditions": [
+      "tradition_carthage_sea_empire",
+      "tradition_carthage_trade_law"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "naval_marines",
+        "territoryId": "carthage_carthage",
+        "strength": 6
+      },
+      {
+        "unitId": "desert_scouts",
+        "territoryId": "carthage_maghrib",
+        "strength": 5
+      }
+    ],
+    "startingTechs": [
+      "tech_navigation"
+    ],
+    "startingMissions": [
+      "mission_dominate_sea"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "sea_trade"
+    ],
+    "startingTreasury": 27
   },
   {
     "id": "scythia",
     "name": "Scythia",
     "description": "Nomadic confederations patrolling the steppe with composite bows and raiding savvy.",
-    "territories": ["scythia_steppe", "scythia_caspian", "scythia_borderlands"],
+    "territories": [
+      "scythia_steppe",
+      "scythia_caspian",
+      "scythia_borderlands"
+    ],
     "stats": {
       "stability": 58,
       "military": 78,
@@ -172,13 +682,97 @@
     "disadvantages": [
       "Loose Confederacy: Passing laws reduces support by 3.",
       "Nomad Crime: Crime decays 1 point slower."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 6
+      },
+      {
+        "type": "horses",
+        "amount": 12
+      },
+      {
+        "type": "timber",
+        "amount": 3
+      }
+    ],
+    "characters": [
+      {
+        "id": "scythia_idanthyrsus",
+        "name": "Idanthyrsus",
+        "role": "ruler",
+        "loyalty": 70,
+        "traits": [
+          "Master Rider",
+          "Steppe Envoy"
+        ]
+      },
+      {
+        "id": "scythia_tomyris",
+        "name": "Tomyris",
+        "role": "general",
+        "loyalty": 74,
+        "traits": [
+          "Nomad Queen",
+          "Ambush Savant"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "scythia_raiders",
+        "name": "Raider Clans",
+        "agenda": "Raid frontier farms for tribute",
+        "approval": 60,
+        "influence": 58,
+        "leaderId": "scythia_tomyris"
+      },
+      {
+        "id": "scythia_sages",
+        "name": "Sky Shamans",
+        "agenda": "Keep peace among rival clans",
+        "approval": 55,
+        "influence": 52,
+        "leaderId": "scythia_idanthyrsus"
+      }
+    ],
+    "traditions": [
+      "tradition_scythia_nomad_bows",
+      "tradition_scythia_wind_riders"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "steppe_raiders",
+        "territoryId": "scythia_steppe",
+        "strength": 7
+      },
+      {
+        "unitId": "horse_archers",
+        "territoryId": "scythia_borderlands",
+        "strength": 7
+      }
+    ],
+    "startingTechs": [
+      "tech_composite_bow"
+    ],
+    "startingMissions": [
+      "mission_raid_frontier"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "nomad_thunder"
+    ],
+    "startingTreasury": 18
   },
   {
     "id": "egypt",
     "name": "Egypt",
     "description": "Nile dynasts sustaining bureaucracy and monumental projects through predictable floods.",
-    "territories": ["egypt_delta", "egypt_upper"],
+    "territories": [
+      "egypt_delta",
+      "egypt_upper"
+    ],
     "stats": {
       "stability": 82,
       "military": 64,
@@ -195,15 +789,100 @@
       "Vizier Cadres: Pass Law increases laws by an additional 2."
     ],
     "disadvantages": [
-      "Labor Corvée: Suppress Crime reduces support by 2.",
+      "Labor Corv\u00e9e: Suppress Crime reduces support by 2.",
       "Desert Supply: Armies outside Nile tiles lose 1 strength per turn."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 16
+      },
+      {
+        "type": "stone",
+        "amount": 8
+      },
+      {
+        "type": "luxuries",
+        "amount": 6
+      }
+    ],
+    "characters": [
+      {
+        "id": "egypt_hatshepsut",
+        "name": "Hatshepsut",
+        "role": "ruler",
+        "loyalty": 88,
+        "traits": [
+          "Divine Builder",
+          "Diplomatic Bridge"
+        ]
+      },
+      {
+        "id": "egypt_thutmose",
+        "name": "Thutmose",
+        "role": "general",
+        "loyalty": 77,
+        "traits": [
+          "Nile Commander",
+          "Desert Scout"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "egypt_priesthood",
+        "name": "Priests of Amun",
+        "agenda": "Fund temple projects and rituals",
+        "approval": 75,
+        "influence": 80,
+        "leaderId": "egypt_hatshepsut"
+      },
+      {
+        "id": "egypt_navy",
+        "name": "Nile Fleetmasters",
+        "agenda": "Secure river trade and supply routes",
+        "approval": 68,
+        "influence": 65,
+        "leaderId": "egypt_thutmose"
+      }
+    ],
+    "traditions": [
+      "tradition_egypt_river_bounty",
+      "tradition_egypt_monumental"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "levy_infantry",
+        "territoryId": "egypt_delta",
+        "strength": 6
+      },
+      {
+        "unitId": "royal_guard",
+        "territoryId": "egypt_upper",
+        "strength": 8
+      }
+    ],
+    "startingTechs": [
+      "tech_irrigation"
+    ],
+    "startingMissions": [
+      "mission_honour_nile"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "nile_empire"
+    ],
+    "startingTreasury": 28
   },
   {
     "id": "rome",
     "name": "Rome",
     "description": "Ambitious republic leveraging disciplined legions, civic roads, and resilient citizenry.",
-    "territories": ["rome_etruria", "rome_latium", "rome_campania"],
+    "territories": [
+      "rome_etruria",
+      "rome_latium",
+      "rome_campania"
+    ],
     "stats": {
       "stability": 74,
       "military": 80,
@@ -222,13 +901,102 @@
     "disadvantages": [
       "Class Tensions: Collect Taxes adds +2 crime if support <65.",
       "Senate Debates: Diplomacy Offer effectiveness reduced by 1 relation."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 13
+      },
+      {
+        "type": "stone",
+        "amount": 7
+      },
+      {
+        "type": "timber",
+        "amount": 6
+      }
+    ],
+    "characters": [
+      {
+        "id": "rome_brutus",
+        "name": "Lucius Brutus",
+        "role": "ruler",
+        "loyalty": 76,
+        "traits": [
+          "Republic Founder",
+          "Consular Authority"
+        ]
+      },
+      {
+        "id": "rome_camillus",
+        "name": "Marcus Camillus",
+        "role": "general",
+        "loyalty": 74,
+        "traits": [
+          "Legion Organizer",
+          "Engineer of Roads"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "rome_senate",
+        "name": "Senatorial Bloc",
+        "agenda": "Invest in civic roads and colonies",
+        "approval": 66,
+        "influence": 70,
+        "leaderId": "rome_brutus"
+      },
+      {
+        "id": "rome_legions",
+        "name": "Legion Tribunes",
+        "agenda": "Expand legion training and fort lines",
+        "approval": 64,
+        "influence": 68,
+        "leaderId": "rome_camillus"
+      }
+    ],
+    "traditions": [
+      "tradition_rome_legionary_discipline",
+      "tradition_rome_civic_roads"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "levy_infantry",
+        "territoryId": "rome_latium",
+        "strength": 6
+      },
+      {
+        "unitId": "bronze_spearmen",
+        "territoryId": "rome_etruria",
+        "strength": 7
+      },
+      {
+        "unitId": "war_chariots",
+        "territoryId": "rome_campania",
+        "strength": 7
+      }
+    ],
+    "startingTechs": [
+      "tech_military_roads"
+    ],
+    "startingMissions": [
+      "mission_expand_republic"
+    ],
+    "scenarioTags": [
+      "classical_age",
+      "italian_rise"
+    ],
+    "startingTreasury": 26
   },
   {
     "id": "minoa",
     "name": "Minoa",
     "description": "Aegean maritime power controlling key islands with vibrant artisan guilds.",
-    "territories": ["minoa_aegean", "minoa_crete"],
+    "territories": [
+      "minoa_aegean",
+      "minoa_crete"
+    ],
     "stats": {
       "stability": 68,
       "military": 58,
@@ -247,13 +1015,97 @@
     "disadvantages": [
       "Earthquake Threat: Random events can hit stability harder (-1 additional).",
       "No Standing Army: Recruit Army costs +1 economy."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 7
+      },
+      {
+        "type": "luxuries",
+        "amount": 8
+      },
+      {
+        "type": "timber",
+        "amount": 5
+      }
+    ],
+    "characters": [
+      {
+        "id": "minoa_minossa",
+        "name": "Queen Minossa",
+        "role": "ruler",
+        "loyalty": 79,
+        "traits": [
+          "Sea Throne",
+          "Labyrinth Patron"
+        ]
+      },
+      {
+        "id": "minoa_daedalus",
+        "name": "Daedalus",
+        "role": "sage",
+        "loyalty": 71,
+        "traits": [
+          "Artisan Genius",
+          "Harbor Architect"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "minoa_traders",
+        "name": "Aegean Traders",
+        "agenda": "Restore island trade dominance",
+        "approval": 69,
+        "influence": 70,
+        "leaderId": "minoa_minossa"
+      },
+      {
+        "id": "minoa_artisans",
+        "name": "Palatial Artisans",
+        "agenda": "Fund artisan guilds and festivals",
+        "approval": 65,
+        "influence": 62,
+        "leaderId": "minoa_daedalus"
+      }
+    ],
+    "traditions": [
+      "tradition_minoa_sea_lords",
+      "tradition_minoa_palatial_craft"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "naval_marines",
+        "territoryId": "minoa_aegean",
+        "strength": 6
+      },
+      {
+        "unitId": "palace_guard",
+        "territoryId": "minoa_crete",
+        "strength": 7
+      }
+    ],
+    "startingTechs": [
+      "tech_sea_trade"
+    ],
+    "startingMissions": [
+      "mission_reopen_trade"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "aegean_supremacy"
+    ],
+    "startingTreasury": 24
   },
   {
     "id": "hittites",
     "name": "Hittites",
     "description": "Anatolian federation famed for chariot corps and complex legal code.",
-    "territories": ["hittites_anatolia", "hittites_capital"],
+    "territories": [
+      "hittites_anatolia",
+      "hittites_capital"
+    ],
     "stats": {
       "stability": 71,
       "military": 77,
@@ -272,6 +1124,87 @@
     "disadvantages": [
       "Vassal Disputes: Alliances reduce stability by 1 due to obligations.",
       "Mountain Routes: Move Army into Anatolia tiles costs +1 strength."
-    ]
+    ],
+    "resourceInventory": [
+      {
+        "type": "grain",
+        "amount": 10
+      },
+      {
+        "type": "bronze",
+        "amount": 9
+      },
+      {
+        "type": "stone",
+        "amount": 7
+      }
+    ],
+    "characters": [
+      {
+        "id": "hittites_suppiluliuma",
+        "name": "Suppiluliuma",
+        "role": "ruler",
+        "loyalty": 83,
+        "traits": [
+          "Lawgiver King",
+          "Chariot Tactician"
+        ]
+      },
+      {
+        "id": "hittites_puduhepa",
+        "name": "Puduhepa",
+        "role": "diplomat",
+        "loyalty": 76,
+        "traits": [
+          "Priestess Mediator",
+          "Treaty Weaver"
+        ]
+      }
+    ],
+    "factions": [
+      {
+        "id": "hittites_nobles",
+        "name": "Anatolian Nobles",
+        "agenda": "Codify vassal treaties and secure borders",
+        "approval": 67,
+        "influence": 69,
+        "leaderId": "hittites_suppiluliuma"
+      },
+      {
+        "id": "hittites_chariots",
+        "name": "Royal Chariot Corps",
+        "agenda": "Invest in elite chariot regiments",
+        "approval": 62,
+        "influence": 65,
+        "leaderId": "hittites_puduhepa"
+      }
+    ],
+    "traditions": [
+      "tradition_hittites_law_tablets",
+      "tradition_hittites_chariot_legions"
+    ],
+    "startingUnits": [
+      {
+        "unitId": "war_chariots",
+        "territoryId": "hittites_anatolia",
+        "strength": 8
+      },
+      {
+        "unitId": "bronze_spearmen",
+        "territoryId": "hittites_capital",
+        "strength": 7
+      }
+    ],
+    "startingTechs": [
+      "tech_bronze_working"
+    ],
+    "startingMissions": [
+      "mission_codify_laws"
+    ],
+    "scenarioTags": [
+      "bronze_age",
+      "anatolian_hegemony"
+    ],
+    "startingTreasury": 23
   }
 ]

--- a/frontend/src/data/tech.json
+++ b/frontend/src/data/tech.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "tech_bronze_working",
+    "name": "Bronze Working",
+    "tier": 1,
+    "prerequisites": [],
+    "effects": ["Unlocks Bronze Spearmen", "+1 military stat on adoption"]
+  },
+  {
+    "id": "tech_horse_domestication",
+    "name": "Horse Domestication",
+    "tier": 1,
+    "prerequisites": [],
+    "effects": ["Unlocks Horse Archers", "Supply upkeep -1 for cavalry"]
+  },
+  {
+    "id": "tech_ritual_divination",
+    "name": "Ritual Divination",
+    "tier": 2,
+    "prerequisites": ["tech_bronze_working"],
+    "effects": ["Unlocks War Chariots", "Positive events yield +1 stability"]
+  },
+  {
+    "id": "tech_wheel_siege",
+    "name": "Siege Wheelcraft",
+    "tier": 2,
+    "prerequisites": ["tech_bronze_working"],
+    "effects": ["Unlocks Siege Engineers", "Fortification bonus reduced by 1 during assaults"]
+  },
+  {
+    "id": "tech_navigation",
+    "name": "Open Sea Navigation",
+    "tier": 2,
+    "prerequisites": ["tech_bronze_working"],
+    "effects": ["Unlocks Naval Marines", "Unlocks Desert Scouts", "+1 economy from coastal tiles"]
+  },
+  {
+    "id": "tech_composite_bow",
+    "name": "Composite Bowcraft",
+    "tier": 2,
+    "prerequisites": ["tech_horse_domestication"],
+    "effects": ["Unlocks Steppe Raiders", "Skirmish actions gain +10% effectiveness"]
+  },
+  {
+    "id": "tech_irrigation",
+    "name": "Irrigation Basins",
+    "tier": 1,
+    "prerequisites": [],
+    "effects": ["Unlocks Royal Guard", "+1 grain output from river tiles"]
+  },
+  {
+    "id": "tech_hydraulic_engineering",
+    "name": "Hydraulic Engineering",
+    "tier": 2,
+    "prerequisites": ["tech_irrigation"],
+    "effects": ["+1 development per turn in canal territories", "Unlocks canal events"]
+  },
+  {
+    "id": "tech_military_roads",
+    "name": "Military Roads",
+    "tier": 2,
+    "prerequisites": ["tech_bronze_working"],
+    "effects": ["Move Army cost -1", "+1 supply to units ending turn on roads"]
+  },
+  {
+    "id": "tech_sea_trade",
+    "name": "Sea Trade Networks",
+    "tier": 2,
+    "prerequisites": ["tech_navigation"],
+    "effects": ["Unlocks Palace Guard", "+1 influence from coastal alliances"]
+  },
+  {
+    "id": "tech_iron_forging",
+    "name": "Early Iron Forging",
+    "tier": 3,
+    "prerequisites": ["tech_bronze_working"],
+    "effects": ["+5 military", "Armies ignore 1 fortification level"]
+  }
+]

--- a/frontend/src/data/territories.json
+++ b/frontend/src/data/territories.json
@@ -2,217 +2,939 @@
   {
     "id": "rome_etruria",
     "name": "Etruria",
-    "coordinates": [1, 0],
+    "coordinates": [
+      1,
+      0
+    ],
     "terrain": "hills",
-    "neighbors": ["rome_latium", "minoa_aegean", "hittites_anatolia"],
-    "ownerId": "rome"
+    "neighbors": [
+      "rome_latium",
+      "minoa_aegean",
+      "hittites_anatolia"
+    ],
+    "ownerId": "rome",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Tuscan farms"
+      },
+      {
+        "type": "timber",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Oak-laden hills"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "rome_latium",
     "name": "Latium",
-    "coordinates": [2, 0],
+    "coordinates": [
+      2,
+      0
+    ],
     "terrain": "plains",
-    "neighbors": ["rome_etruria", "rome_campania", "minoa_aegean"],
-    "ownerId": "rome"
+    "neighbors": [
+      "rome_etruria",
+      "rome_campania",
+      "minoa_aegean"
+    ],
+    "ownerId": "rome",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Latium plains"
+      },
+      {
+        "type": "stone",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Tiber quarries"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2,
+      "supplyBonus": 1
+    }
   },
   {
     "id": "rome_campania",
     "name": "Campania",
-    "coordinates": [3, 0],
+    "coordinates": [
+      3,
+      0
+    ],
     "terrain": "coastal",
-    "neighbors": ["rome_latium", "carthage_carthage", "minoa_crete"],
-    "ownerId": "rome"
+    "neighbors": [
+      "rome_latium",
+      "carthage_carthage",
+      "minoa_crete"
+    ],
+    "ownerId": "rome",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Volcanic soils"
+      },
+      {
+        "type": "luxuries",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Wine and garum"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "carthage_carthage",
     "name": "Carthage",
-    "coordinates": [3, 1],
+    "coordinates": [
+      3,
+      1
+    ],
     "terrain": "coastal",
-    "neighbors": ["rome_campania", "carthage_maghrib", "minoa_crete", "egypt_delta"],
-    "ownerId": "carthage"
+    "neighbors": [
+      "rome_campania",
+      "carthage_maghrib",
+      "minoa_crete",
+      "egypt_delta"
+    ],
+    "ownerId": "carthage",
+    "resources": [
+      {
+        "type": "luxuries",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Purple dye workshops"
+      },
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "North African fields"
+      }
+    ],
+    "fortifications": {
+      "level": 3,
+      "type": "citadel",
+      "garrisonBonus": 3,
+      "supplyBonus": 2
+    }
   },
   {
     "id": "carthage_maghrib",
     "name": "Maghrib",
-    "coordinates": [4, 1],
+    "coordinates": [
+      4,
+      1
+    ],
     "terrain": "desert",
-    "neighbors": ["carthage_carthage", "egypt_upper"],
-    "ownerId": "carthage"
+    "neighbors": [
+      "carthage_carthage",
+      "egypt_upper"
+    ],
+    "ownerId": "carthage",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "scarce",
+        "output": 2,
+        "notes": "Desert oases"
+      },
+      {
+        "type": "timber",
+        "richness": "scarce",
+        "output": 2,
+        "notes": "Coastal scrub"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "minoa_aegean",
     "name": "Aegean Isles",
-    "coordinates": [2, 1],
+    "coordinates": [
+      2,
+      1
+    ],
     "terrain": "coastal",
-    "neighbors": ["rome_etruria", "rome_latium", "minoa_crete", "hittites_capital"],
-    "ownerId": "minoa"
+    "neighbors": [
+      "rome_etruria",
+      "rome_latium",
+      "minoa_crete",
+      "hittites_capital"
+    ],
+    "ownerId": "minoa",
+    "resources": [
+      {
+        "type": "luxuries",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Artisan goods"
+      },
+      {
+        "type": "timber",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Ship masts"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2,
+      "supplyBonus": 1
+    }
   },
   {
     "id": "minoa_crete",
     "name": "Crete",
-    "coordinates": [3, 2],
+    "coordinates": [
+      3,
+      2
+    ],
     "terrain": "coastal",
-    "neighbors": ["rome_campania", "carthage_carthage", "minoa_aegean", "egypt_delta"],
-    "ownerId": "minoa"
+    "neighbors": [
+      "rome_campania",
+      "carthage_carthage",
+      "minoa_aegean",
+      "egypt_delta"
+    ],
+    "ownerId": "minoa",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Terraced fields"
+      },
+      {
+        "type": "luxuries",
+        "richness": "abundant",
+        "output": 4,
+        "notes": "Palatial workshops"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "hittites_anatolia",
     "name": "Western Anatolia",
-    "coordinates": [1, 1],
+    "coordinates": [
+      1,
+      1
+    ],
     "terrain": "mountain",
-    "neighbors": ["rome_etruria", "minoa_aegean", "hittites_capital", "scythia_borderlands"],
-    "ownerId": "hittites"
+    "neighbors": [
+      "rome_etruria",
+      "minoa_aegean",
+      "hittites_capital",
+      "scythia_borderlands"
+    ],
+    "ownerId": "hittites",
+    "resources": [
+      {
+        "type": "stone",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Anatolian ridges"
+      },
+      {
+        "type": "timber",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Mountain forests"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "hittites_capital",
     "name": "Hattusa",
-    "coordinates": [2, 2],
+    "coordinates": [
+      2,
+      2
+    ],
     "terrain": "mountain",
-    "neighbors": ["minoa_aegean", "hittites_anatolia", "assyria_upper", "assyria_heartland"],
-    "ownerId": "hittites"
+    "neighbors": [
+      "minoa_aegean",
+      "hittites_anatolia",
+      "assyria_upper",
+      "assyria_heartland"
+    ],
+    "ownerId": "hittites",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "River valleys"
+      },
+      {
+        "type": "bronze",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Smelting works"
+      }
+    ],
+    "fortifications": {
+      "level": 3,
+      "type": "citadel",
+      "garrisonBonus": 3,
+      "supplyBonus": 1
+    }
   },
   {
     "id": "assyria_upper",
     "name": "Upper Assyria",
-    "coordinates": [1, 3],
+    "coordinates": [
+      1,
+      3
+    ],
     "terrain": "hills",
-    "neighbors": ["hittites_capital", "assyria_heartland", "scythia_borderlands", "akkad_mesopotamia"],
-    "ownerId": "assyria"
+    "neighbors": [
+      "hittites_capital",
+      "assyria_heartland",
+      "scythia_borderlands",
+      "akkad_mesopotamia"
+    ],
+    "ownerId": "assyria",
+    "resources": [
+      {
+        "type": "horses",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Steppe pastures"
+      },
+      {
+        "type": "timber",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Hill forests"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "assyria_heartland",
     "name": "Assur",
-    "coordinates": [2, 3],
+    "coordinates": [
+      2,
+      3
+    ],
     "terrain": "plains",
-    "neighbors": ["hittites_capital", "assyria_upper", "akkad_mesopotamia", "akkad_lower"],
-    "ownerId": "assyria"
+    "neighbors": [
+      "hittites_capital",
+      "assyria_upper",
+      "akkad_mesopotamia",
+      "akkad_lower"
+    ],
+    "ownerId": "assyria",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Assur granaries"
+      },
+      {
+        "type": "stone",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Temple quarries"
+      }
+    ],
+    "fortifications": {
+      "level": 3,
+      "type": "citadel",
+      "garrisonBonus": 3,
+      "supplyBonus": 1
+    }
   },
   {
     "id": "akkad_mesopotamia",
     "name": "Akkad",
-    "coordinates": [2, 4],
+    "coordinates": [
+      2,
+      4
+    ],
     "terrain": "plains",
-    "neighbors": ["assyria_upper", "assyria_heartland", "akkad_lower", "medes_plateau"],
-    "ownerId": "akkad"
+    "neighbors": [
+      "assyria_upper",
+      "assyria_heartland",
+      "akkad_lower",
+      "medes_plateau"
+    ],
+    "ownerId": "akkad",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Euphrates irrigation"
+      },
+      {
+        "type": "bronze",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Craft guilds"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "akkad_lower",
     "name": "Lower Mesopotamia",
-    "coordinates": [3, 4],
+    "coordinates": [
+      3,
+      4
+    ],
     "terrain": "river",
-    "neighbors": ["assyria_heartland", "akkad_mesopotamia", "egypt_delta", "medes_plateau", "harappa_indus"],
-    "ownerId": "akkad"
+    "neighbors": [
+      "assyria_heartland",
+      "akkad_mesopotamia",
+      "egypt_delta",
+      "medes_plateau",
+      "harappa_indus"
+    ],
+    "ownerId": "akkad",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Delta fields"
+      },
+      {
+        "type": "luxuries",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Reed barges"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "egypt_delta",
     "name": "Lower Nile",
-    "coordinates": [3, 3],
+    "coordinates": [
+      3,
+      3
+    ],
     "terrain": "river",
-    "neighbors": ["carthage_carthage", "minoa_crete", "akkad_lower", "egypt_upper"],
-    "ownerId": "egypt"
+    "neighbors": [
+      "carthage_carthage",
+      "minoa_crete",
+      "akkad_lower",
+      "egypt_upper"
+    ],
+    "ownerId": "egypt",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "abundant",
+        "output": 6,
+        "notes": "Nile floodplains"
+      },
+      {
+        "type": "luxuries",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Papyrus workshops"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2,
+      "supplyBonus": 1
+    }
   },
   {
     "id": "egypt_upper",
     "name": "Upper Nile",
-    "coordinates": [4, 3],
+    "coordinates": [
+      4,
+      3
+    ],
     "terrain": "river",
-    "neighbors": ["egypt_delta", "carthage_maghrib", "medes_frontier"],
-    "ownerId": "egypt"
+    "neighbors": [
+      "egypt_delta",
+      "carthage_maghrib",
+      "medes_frontier"
+    ],
+    "ownerId": "egypt",
+    "resources": [
+      {
+        "type": "stone",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Nubian quarries"
+      },
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Canal oases"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "medes_caspian",
     "name": "Caspian Gates",
-    "coordinates": [1, 4],
+    "coordinates": [
+      1,
+      4
+    ],
     "terrain": "mountain",
-    "neighbors": ["assyria_upper", "medes_plateau", "scythia_caspian"],
-    "ownerId": "medes"
+    "neighbors": [
+      "assyria_upper",
+      "medes_plateau",
+      "scythia_caspian"
+    ],
+    "ownerId": "medes",
+    "resources": [
+      {
+        "type": "timber",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Forest passes"
+      },
+      {
+        "type": "stone",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Caspian ridges"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "medes_plateau",
     "name": "Median Plateau",
-    "coordinates": [2, 5],
+    "coordinates": [
+      2,
+      5
+    ],
     "terrain": "hills",
-    "neighbors": ["akkad_mesopotamia", "akkad_lower", "medes_caspian", "medes_frontier", "harappa_indus"],
-    "ownerId": "medes"
+    "neighbors": [
+      "akkad_mesopotamia",
+      "akkad_lower",
+      "medes_caspian",
+      "medes_frontier",
+      "harappa_indus"
+    ],
+    "ownerId": "medes",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Highland terraces"
+      },
+      {
+        "type": "horses",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Plateau pastures"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "medes_frontier",
     "name": "Eastern Frontier",
-    "coordinates": [4, 4],
+    "coordinates": [
+      4,
+      4
+    ],
     "terrain": "mountain",
-    "neighbors": ["egypt_upper", "medes_plateau", "harappa_meluha"],
-    "ownerId": "medes"
+    "neighbors": [
+      "egypt_upper",
+      "medes_plateau",
+      "harappa_meluha"
+    ],
+    "ownerId": "medes",
+    "resources": [
+      {
+        "type": "horses",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Frontier herds"
+      },
+      {
+        "type": "timber",
+        "richness": "scarce",
+        "output": 2,
+        "notes": "Sparse copses"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2,
+      "supplyBonus": 1
+    }
   },
   {
     "id": "harappa_indus",
     "name": "Indus Heartland",
-    "coordinates": [2, 6],
+    "coordinates": [
+      2,
+      6
+    ],
     "terrain": "river",
-    "neighbors": ["medes_plateau", "akkad_lower", "harappa_meluha", "shang_yellow"],
-    "ownerId": "harappa"
+    "neighbors": [
+      "medes_plateau",
+      "akkad_lower",
+      "harappa_meluha",
+      "shang_yellow"
+    ],
+    "ownerId": "harappa",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "abundant",
+        "output": 6,
+        "notes": "Canalized fields"
+      },
+      {
+        "type": "stone",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Brick kilns"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "harappa_meluha",
     "name": "Meluha Coast",
-    "coordinates": [3, 5],
+    "coordinates": [
+      3,
+      5
+    ],
     "terrain": "coastal",
-    "neighbors": ["medes_plateau", "harappa_indus", "medes_frontier", "harappa_sindh"],
-    "ownerId": "harappa"
+    "neighbors": [
+      "medes_plateau",
+      "harappa_indus",
+      "medes_frontier",
+      "harappa_sindh"
+    ],
+    "ownerId": "harappa",
+    "resources": [
+      {
+        "type": "luxuries",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Seaborne trade"
+      },
+      {
+        "type": "timber",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Delta groves"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "harappa_sindh",
     "name": "Sindh Delta",
-    "coordinates": [4, 5],
+    "coordinates": [
+      4,
+      5
+    ],
     "terrain": "coastal",
-    "neighbors": ["harappa_meluha", "medes_frontier", "shang_delta"],
-    "ownerId": "harappa"
+    "neighbors": [
+      "harappa_meluha",
+      "medes_frontier",
+      "shang_delta"
+    ],
+    "ownerId": "harappa",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Sindh fisheries"
+      },
+      {
+        "type": "luxuries",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Trade beads"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "shang_yellow",
     "name": "Yellow River",
-    "coordinates": [2, 7],
+    "coordinates": [
+      2,
+      7
+    ],
     "terrain": "river",
-    "neighbors": ["harappa_indus", "shang_delta", "scythia_east"],
-    "ownerId": "shang"
+    "neighbors": [
+      "harappa_indus",
+      "shang_delta",
+      "scythia_east"
+    ],
+    "ownerId": "shang",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "abundant",
+        "output": 6,
+        "notes": "Loess farmlands"
+      },
+      {
+        "type": "bronze",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Foundry towns"
+      }
+    ],
+    "fortifications": {
+      "level": 2,
+      "type": "stone",
+      "garrisonBonus": 2
+    }
   },
   {
     "id": "shang_delta",
     "name": "Eastern Delta",
-    "coordinates": [3, 6],
+    "coordinates": [
+      3,
+      6
+    ],
     "terrain": "coastal",
-    "neighbors": ["harappa_meluha", "harappa_sindh", "shang_yellow"],
-    "ownerId": "shang"
+    "neighbors": [
+      "harappa_meluha",
+      "harappa_sindh",
+      "shang_yellow"
+    ],
+    "ownerId": "shang",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Delta paddies"
+      },
+      {
+        "type": "luxuries",
+        "richness": "standard",
+        "output": 3,
+        "notes": "Oracle shells"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "scythia_steppe",
     "name": "Great Steppe",
-    "coordinates": [0, 3],
+    "coordinates": [
+      0,
+      3
+    ],
     "terrain": "steppe",
-    "neighbors": ["scythia_borderlands", "scythia_caspian"],
-    "ownerId": "scythia"
+    "neighbors": [
+      "scythia_borderlands",
+      "scythia_caspian"
+    ],
+    "ownerId": "scythia",
+    "resources": [
+      {
+        "type": "horses",
+        "richness": "abundant",
+        "output": 6,
+        "notes": "Endless grasslands"
+      },
+      {
+        "type": "grain",
+        "richness": "scarce",
+        "output": 2,
+        "notes": "Nomad farms"
+      }
+    ],
+    "fortifications": {
+      "level": 0,
+      "type": "none",
+      "garrisonBonus": 0
+    }
   },
   {
     "id": "scythia_caspian",
     "name": "Caspian Steppe",
-    "coordinates": [0, 4],
+    "coordinates": [
+      0,
+      4
+    ],
     "terrain": "steppe",
-    "neighbors": ["scythia_steppe", "medes_caspian", "scythia_east"],
-    "ownerId": "scythia"
+    "neighbors": [
+      "scythia_steppe",
+      "medes_caspian",
+      "scythia_east"
+    ],
+    "ownerId": "scythia",
+    "resources": [
+      {
+        "type": "horses",
+        "richness": "abundant",
+        "output": 5,
+        "notes": "Coastal steppes"
+      },
+      {
+        "type": "timber",
+        "richness": "scarce",
+        "output": 2,
+        "notes": "River woods"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "scythia_borderlands",
     "name": "Border Marches",
-    "coordinates": [1, 2],
+    "coordinates": [
+      1,
+      2
+    ],
     "terrain": "steppe",
-    "neighbors": ["scythia_steppe", "hittites_anatolia", "assyria_upper"],
-    "ownerId": "scythia"
+    "neighbors": [
+      "scythia_steppe",
+      "hittites_anatolia",
+      "assyria_upper"
+    ],
+    "ownerId": "scythia",
+    "resources": [
+      {
+        "type": "horses",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Border corrals"
+      },
+      {
+        "type": "timber",
+        "richness": "scarce",
+        "output": 2,
+        "notes": "Scrub brush"
+      }
+    ],
+    "fortifications": {
+      "level": 1,
+      "type": "palisade",
+      "garrisonBonus": 1
+    }
   },
   {
     "id": "scythia_east",
     "name": "Far Steppe",
-    "coordinates": [1, 5],
+    "coordinates": [
+      1,
+      5
+    ],
     "terrain": "steppe",
-    "neighbors": ["scythia_caspian", "medes_plateau", "shang_yellow"],
-    "ownerId": "scythia"
+    "neighbors": [
+      "scythia_caspian",
+      "medes_plateau",
+      "shang_yellow"
+    ],
+    "ownerId": "scythia",
+    "resources": [
+      {
+        "type": "grain",
+        "richness": "scarce",
+        "output": 2,
+        "notes": "Rugged steppes"
+      },
+      {
+        "type": "horses",
+        "richness": "standard",
+        "output": 4,
+        "notes": "Nomad herds"
+      }
+    ],
+    "fortifications": {
+      "level": 0,
+      "type": "none",
+      "garrisonBonus": 0
+    }
   }
 ]

--- a/frontend/src/data/units.json
+++ b/frontend/src/data/units.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "levy_infantry",
+    "name": "Levy Infantry",
+    "category": "infantry",
+    "baseStrength": 6,
+    "maxSupply": 5,
+    "upkeep": 1,
+    "supplyUse": 1,
+    "abilities": ["Citizen levies rally quickly"],
+    "description": "Citizen militias providing the backbone of early armies."
+  },
+  {
+    "id": "bronze_spearmen",
+    "name": "Bronze Spearmen",
+    "category": "infantry",
+    "baseStrength": 7,
+    "maxSupply": 6,
+    "upkeep": 2,
+    "supplyUse": 1,
+    "abilities": ["Hold the line", "Bonus vs cavalry"],
+    "techRequirement": "tech_bronze_working",
+    "description": "Disciplined heavy infantry wielding bronze shields and spears."
+  },
+  {
+    "id": "horse_archers",
+    "name": "Horse Archers",
+    "category": "cavalry",
+    "baseStrength": 7,
+    "maxSupply": 7,
+    "upkeep": 2,
+    "supplyUse": 2,
+    "abilities": ["Mobile volley", "Strike from steppe"],
+    "techRequirement": "tech_horse_domestication",
+    "description": "Mounted archers capable of rapid raids and encirclements."
+  },
+  {
+    "id": "war_chariots",
+    "name": "War Chariots",
+    "category": "cavalry",
+    "baseStrength": 8,
+    "maxSupply": 6,
+    "upkeep": 3,
+    "supplyUse": 2,
+    "abilities": ["Shock charge", "Elite escort"],
+    "techRequirement": "tech_ritual_divination",
+    "description": "Ornate chariots that deliver devastating charges."
+  },
+  {
+    "id": "siege_engineers",
+    "name": "Siege Engineers",
+    "category": "siege",
+    "baseStrength": 5,
+    "maxSupply": 4,
+    "upkeep": 3,
+    "supplyUse": 2,
+    "abilities": ["Reduces fortification bonuses"],
+    "techRequirement": "tech_wheel_siege",
+    "description": "Specialists hauling rams and towers to breach defenses."
+  },
+  {
+    "id": "naval_marines",
+    "name": "Naval Marines",
+    "category": "naval",
+    "baseStrength": 6,
+    "maxSupply": 6,
+    "upkeep": 2,
+    "supplyUse": 1,
+    "abilities": ["Amphibious assault", "Harbor defense"],
+    "techRequirement": "tech_navigation",
+    "description": "Sea-seasoned infantry that protect harbors and board enemy ships."
+  },
+  {
+    "id": "desert_scouts",
+    "name": "Desert Scouts",
+    "category": "cavalry",
+    "baseStrength": 6,
+    "maxSupply": 5,
+    "upkeep": 1,
+    "supplyUse": 1,
+    "abilities": ["Ignore desert attrition"],
+    "techRequirement": "tech_navigation",
+    "description": "Light cavalry adept at navigating dunes and oasis trails."
+  },
+  {
+    "id": "steppe_raiders",
+    "name": "Steppe Raiders",
+    "category": "cavalry",
+    "baseStrength": 7,
+    "maxSupply": 7,
+    "upkeep": 2,
+    "supplyUse": 2,
+    "abilities": ["Ambush supply lines"],
+    "techRequirement": "tech_composite_bow",
+    "description": "Nomadic riders who excel at deep raids and feigned retreats."
+  },
+  {
+    "id": "royal_guard",
+    "name": "Royal Guard",
+    "category": "infantry",
+    "baseStrength": 8,
+    "maxSupply": 6,
+    "upkeep": 3,
+    "supplyUse": 2,
+    "abilities": ["Guard capitals", "Boost stability"],
+    "techRequirement": "tech_irrigation",
+    "description": "Elite palace troops dedicated to defending the crown."
+  },
+  {
+    "id": "palace_guard",
+    "name": "Palace Guard",
+    "category": "infantry",
+    "baseStrength": 7,
+    "maxSupply": 6,
+    "upkeep": 2,
+    "supplyUse": 1,
+    "abilities": ["Protect traditions"],
+    "techRequirement": "tech_sea_trade",
+    "description": "Ceremonial fighters who maintain order in palace complexes."
+  }
+]

--- a/frontend/src/game/ai.ts
+++ b/frontend/src/game/ai.ts
@@ -45,7 +45,7 @@ const considerWarTargets = ({ state, nation, rng }: AIDecisionContext): PlayerAc
   return { type: 'MoveArmy', sourceTerritoryId: targetTile.id, targetTerritoryId: enemy.id }
 }
 
-const defensivePlan = ({ state, nation }: AIDecisionContext): PlayerAction | undefined => {
+const defensivePlan = ({ nation }: AIDecisionContext): PlayerAction | undefined => {
   const worstCrime = nation.stats.crime
   if (worstCrime > 60) {
     return { type: 'SuppressCrime' }

--- a/frontend/src/game/data.ts
+++ b/frontend/src/game/data.ts
@@ -1,5 +1,8 @@
 import nationsRaw from '../data/nations.json'
 import territoriesRaw from '../data/territories.json'
+import unitsRaw from '../data/units.json'
+import techRaw from '../data/tech.json'
+import missionsRaw from '../data/missions.json'
 import configRaw from '../config/config.json'
 import type {
   NationDefinition,
@@ -7,22 +10,76 @@ import type {
   GameConfig,
   NationState,
   TerritoryState,
+  UnitDefinition,
+  TechDefinition,
+  MissionDefinition,
+  NationUnitDeployment,
+  SupplyStatus,
 } from './types'
 
-export const nations: NationDefinition[] = nationsRaw
-export const territories: TerritoryDefinition[] = territoriesRaw
-export const gameConfig: GameConfig = configRaw
+export const units: UnitDefinition[] = unitsRaw as UnitDefinition[]
+export const tech: TechDefinition[] = techRaw as TechDefinition[]
+export const missions: MissionDefinition[] = missionsRaw as MissionDefinition[]
 
-export const buildInitialNationState = (definition: NationDefinition): NationState => ({
-  ...definition,
-  stats: { ...definition.stats },
-  armies: definition.territories.map((territoryId, index) => ({
-    id: `${definition.id}-army-${index + 1}`,
-    territoryId,
-    strength: 6,
-  })),
-  treasury: 20,
-})
+export const nations: NationDefinition[] = nationsRaw as NationDefinition[]
+export const territories: TerritoryDefinition[] = territoriesRaw as TerritoryDefinition[]
+export const gameConfig: GameConfig = configRaw as GameConfig
+
+const defaultUnitId = unitsRaw[0]?.id
+
+const cloneResourceInventory = (resources: NationDefinition['resourceInventory']): NationState['resourceInventory'] =>
+  resources?.map((entry) => ({ ...entry })) ?? []
+
+const cloneCharacters = (characters: NationDefinition['characters']): NationState['characters'] =>
+  characters?.map((character) => ({ ...character, traits: [...character.traits] })) ?? []
+
+const cloneFactions = (factions: NationDefinition['factions']): NationState['factions'] =>
+  factions?.map((faction) => ({ ...faction })) ?? []
+
+const determineSupplyStatus = (current: number, max: number): SupplyStatus => {
+  if (current >= max * 0.66) return 'green'
+  if (current >= max * 0.33) return 'strained'
+  return 'depleted'
+}
+
+export const buildInitialNationState = (definition: NationDefinition): NationState => {
+  const deployments: NationUnitDeployment[] = definition.startingUnits?.length
+    ? definition.startingUnits
+    : definition.territories.map((territoryId) => ({
+        unitId: defaultUnitId ?? 'levy_infantry',
+        territoryId,
+      }))
+
+  const armies = deployments.map((deployment, index) => {
+    const unit = units.find((entry) => entry.id === deployment.unitId)
+    const maxSupply = deployment.currentSupply ?? unit?.maxSupply ?? gameConfig.defaultUnitSupply
+    const strength = deployment.strength ?? unit?.baseStrength ?? gameConfig.armyRecruitStrength
+    const currentSupply = Math.min(maxSupply, deployment.currentSupply ?? maxSupply)
+    return {
+      id: `${definition.id}-army-${index + 1}`,
+      territoryId: deployment.territoryId,
+      strength,
+      unitId: deployment.unitId,
+      currentSupply,
+      maxSupply,
+      supplyStatus: determineSupplyStatus(currentSupply, maxSupply),
+    }
+  })
+
+  return {
+    ...definition,
+    stats: { ...definition.stats },
+    armies,
+    treasury: definition.startingTreasury ?? 20,
+    resourceInventory: cloneResourceInventory(definition.resourceInventory),
+    characters: cloneCharacters(definition.characters),
+    factions: cloneFactions(definition.factions),
+    traditions: definition.traditions ? [...definition.traditions] : [],
+    activeMissions: definition.startingMissions ? [...definition.startingMissions] : [],
+    completedMissions: [],
+    knownTechs: definition.startingTechs ? [...definition.startingTechs] : [],
+  }
+}
 
 export const buildInitialTerritoryState = (
   definition: TerritoryDefinition,
@@ -31,4 +88,5 @@ export const buildInitialTerritoryState = (
   garrison: 5,
   development: 50,
   unrest: 10,
+  supplyCache: definition.resources.reduce((total, resource) => total + Math.round(resource.output / 2), 0),
 })

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -18,6 +18,63 @@ export type TerrainType =
   | 'steppe'
   | 'desert'
 
+export type ResourceType = 'grain' | 'timber' | 'bronze' | 'horses' | 'stone' | 'luxuries'
+
+export interface ResourceStockpile {
+  type: ResourceType
+  amount: number
+  reserved?: number
+}
+
+export type ResourceRichness = 'scarce' | 'abundant' | 'standard'
+
+export interface TerritoryResource {
+  type: ResourceType
+  richness: ResourceRichness
+  output: number
+  notes?: string
+}
+
+export interface FortificationDefinition {
+  level: number
+  type: 'none' | 'palisade' | 'stone' | 'citadel'
+  garrisonBonus: number
+  supplyBonus?: number
+}
+
+export type CharacterRole = 'ruler' | 'general' | 'diplomat' | 'governor' | 'sage'
+
+export interface CharacterDefinition {
+  id: string
+  name: string
+  role: CharacterRole
+  loyalty: number
+  traits: string[]
+}
+
+export interface FactionDefinition {
+  id: string
+  name: string
+  agenda: string
+  approval: number
+  influence: number
+  leaderId?: string
+}
+
+export interface TraditionDefinition {
+  id: string
+  name: string
+  description: string
+  effects: string[]
+}
+
+export interface NationUnitDeployment {
+  unitId: string
+  territoryId: string
+  strength?: number
+  currentSupply?: number
+}
+
 export interface NationDefinition {
   id: string
   name: string
@@ -26,6 +83,15 @@ export interface NationDefinition {
   stats: Record<StatKey, number>
   advantages: string[]
   disadvantages: string[]
+  resourceInventory?: ResourceStockpile[]
+  characters?: CharacterDefinition[]
+  factions?: FactionDefinition[]
+  traditions?: string[]
+  startingUnits?: NationUnitDeployment[]
+  startingTechs?: string[]
+  startingMissions?: string[]
+  scenarioTags?: string[]
+  startingTreasury?: number
 }
 
 export interface TerritoryDefinition {
@@ -35,12 +101,15 @@ export interface TerritoryDefinition {
   terrain: TerrainType
   neighbors: string[]
   ownerId: string
+  resources: TerritoryResource[]
+  fortifications: FortificationDefinition
 }
 
 export interface TerritoryState extends TerritoryDefinition {
   garrison: number
   development: number
   unrest: number
+  supplyCache: number
 }
 
 export interface NationState extends NationDefinition {
@@ -48,12 +117,25 @@ export interface NationState extends NationDefinition {
   armies: ArmyUnit[]
   treasury: number
   archetype?: AIArchetype
+  resourceInventory: ResourceStockpile[]
+  characters: CharacterDefinition[]
+  factions: FactionDefinition[]
+  traditions: string[]
+  activeMissions: string[]
+  completedMissions: string[]
+  knownTechs: string[]
 }
+
+export type SupplyStatus = 'green' | 'strained' | 'depleted'
 
 export interface ArmyUnit {
   id: string
   territoryId: string
   strength: number
+  unitId?: string
+  currentSupply: number
+  maxSupply: number
+  supplyStatus: SupplyStatus
 }
 
 export type AIArchetype = 'Expansionist' | 'Defensive' | 'Opportunistic'
@@ -116,6 +198,12 @@ export interface GameConfig {
   baseCrimeGrowth: number
   eventStabilityVariance: number
   eventEconomyVariance: number
+  defaultUnitSupply: number
+  supplyConsumptionPerTurn: number
+  fortificationDefenseBonus: number
+  missionRefreshInterval: number
+  traditionAdoptionCost: number
+  resourceShortagePenalty: number
 }
 
 export interface GameState {
@@ -133,6 +221,8 @@ export interface GameState {
   winner?: string
   defeated?: boolean
   actionsTaken: number
+  scenarioId?: string
+  saveVersion: number
 }
 
 export interface PlayerAction {
@@ -149,4 +239,53 @@ export interface CombatResult {
   outcome: 'attackerVictory' | 'defenderHolds' | 'stalemate'
   attackerLoss: number
   defenderLoss: number
+}
+
+export interface TechDefinition {
+  id: string
+  name: string
+  tier: number
+  prerequisites: string[]
+  effects: string[]
+}
+
+export interface MissionDefinition {
+  id: string
+  name: string
+  description: string
+  rewards: string[]
+  requirements: string[]
+  expiresIn?: number
+}
+
+export interface ScenarioDefinition {
+  id: string
+  name: string
+  description: string
+  recommendedNations: string[]
+  victoryConditions: string[]
+  failureConditions: string[]
+}
+
+export interface SerializedDiplomacyMatrix extends Omit<DiplomacyMatrix, 'wars' | 'alliances'> {
+  wars: string[]
+  alliances: string[]
+}
+
+export interface SavePayload {
+  version: number
+  state: Omit<GameState, 'diplomacy'> & { diplomacy: SerializedDiplomacyMatrix }
+}
+
+export interface UnitDefinition {
+  id: string
+  name: string
+  category: 'infantry' | 'cavalry' | 'naval' | 'siege' | 'support'
+  baseStrength: number
+  maxSupply: number
+  upkeep: number
+  supplyUse: number
+  abilities: string[]
+  techRequirement?: string
+  description: string
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- expand core game types with resource inventories, unit supply metadata, mission and tech definitions, and new config tunables
- populate nations and territories with resource, character, mission, and fortification data and add dedicated units/tech/missions datasets
- embed save-version payload metadata with backward-compatible hydration and adjust UI/utilities for new typings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfda3bb8f88322bdf8be011d534bab