### PR TITLE
Add themed UI panels with localization support and resolve TS build errors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.7",
+        "html-to-image": "^1.11.11",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2923,6 +2924,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/ignore": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.7",
+    "html-to-image": "^1.11.11",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,80 +1,157 @@
 .app-shell {
   min-height: 100vh;
-  padding: 2rem clamp(2rem, 4vw, 4rem);
+  padding: clamp(1.5rem, 2vw + 1rem, 3rem);
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  background: radial-gradient(circle at 10% 10%, rgba(28, 41, 68, 0.85), rgba(6, 10, 18, 0.95));
-}
-
-.app-main {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-.app-content {
-  display: grid;
-  grid-template-columns: 2.5fr 1fr;
   gap: 1.5rem;
+  background: radial-gradient(circle at 12% 8%, rgba(86, 112, 177, 0.2), transparent 60%), var(--color-bg);
+}
+
+.app-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  background: var(--color-surface);
+  border-radius: 1.25rem;
+  padding: 1rem clamp(1rem, 2vw + 0.5rem, 1.75rem);
+  box-shadow: var(--shadow-subtle);
+  flex-wrap: wrap;
+}
+
+.app-toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.app-toolbar label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  gap: 0.35rem;
+}
+
+.app-toolbar select,
+.app-toolbar button {
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  padding: 0.45rem 0.75rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.app-toolbar button:hover,
+.app-toolbar select:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
+  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1fr) minmax(28rem, 2fr) minmax(18rem, 1.2fr);
+  gap: clamp(1.25rem, 2vw, 2rem);
+}
+
+.app-column {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 1.2vw, 1.5rem);
+}
+
+.panel {
+  background: var(--color-surface);
+  border-radius: 1.2rem;
+  padding: clamp(0.9rem, 1vw + 0.4rem, 1.3rem);
+  box-shadow: var(--shadow-soft);
 }
 
 .map-panel {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 1rem;
-  background: var(--surface-panel);
-  border-radius: 1.5rem;
-  padding: 1.25rem;
+  background: var(--color-surface);
+  border-radius: 1.4rem;
+  padding: clamp(1rem, 1.2vw + 0.5rem, 1.6rem);
   box-shadow: var(--shadow-soft);
 }
 
 .map-panel__header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
 }
 
 .map-panel__header h2 {
   margin: 0;
+  font-size: clamp(0.9rem, 0.7rem + 0.4vw, 1.1rem);
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.9rem;
-  color: var(--text-muted);
+  letter-spacing: 0.12em;
+  color: var(--color-text-secondary);
 }
 
 .map-panel__controls {
   display: flex;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .map-panel__controls button {
-  padding: 0.55rem 0.95rem;
-  border-radius: 0.8rem;
-  border: none;
-  background: linear-gradient(135deg, rgba(118, 138, 166, 0.25), rgba(61, 82, 117, 0.45));
-  color: var(--text-strong);
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--color-accent) 24%, transparent), transparent);
+  color: var(--color-text-primary);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .map-panel__controls button:hover {
-  transform: translateY(-2px);
+  transform: translateY(-1px);
   box-shadow: var(--shadow-subtle);
 }
 
-.sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
+.tooltip-depth-basic .panel {
+  backdrop-filter: blur(10px);
 }
 
-@media (max-width: 1200px) {
-  .app-content {
+@media (max-width: 1300px) {
+  .app-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .app-column--right {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-layout {
     grid-template-columns: 1fr;
   }
 
-  .sidebar {
-    order: -1;
+  .app-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .app-toolbar__group {
+    justify-content: space-between;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import NationSelect from './components/NationSelect'
 import HUD from './components/HUD'
 import MapBoard from './components/MapBoard'
@@ -7,74 +7,190 @@ import ActionModal from './components/ActionModal'
 import DiplomacyPanel from './components/DiplomacyPanel'
 import EventLog from './components/EventLog'
 import NotificationStack from './components/NotificationStack'
+import EconomyPanel from './components/EconomyPanel'
+import CourtIntriguePanel from './components/CourtIntriguePanel'
+import TechTree from './components/TechTree'
+import MissionPanel from './components/MissionPanel'
+import OverlayControls, { type OverlayKey } from './components/OverlayControls'
+import MiniMap from './components/MiniMap'
+import AchievementsPanel from './components/AchievementsPanel'
+import HelpCodex from './components/HelpCodex'
+import AudioControls from './components/AudioControls'
+import ScreenshotExporter from './components/ScreenshotExporter'
+import PerformanceStats from './components/PerformanceStats'
+import HotkeyManager from './components/HotkeyManager'
 import { useGameEngine } from './hooks/useGameEngine'
+import { useHotkeys } from './hooks/useHotkeys'
 import { gameConfig, nations as nationDefinitions } from './game/data'
-import type { ActionType } from './game/types'
-import { ACTION_SHORTCUTS } from './game/constants'
+import type { ActionType, NotificationEntry } from './game/types'
+import { useSettings, type ThemeMode, type ColorPalette } from './contexts/SettingsContext'
+import { useTranslation } from './contexts/TranslationContext'
+import type { TranslationKey } from './i18n/translations'
 import './App.css'
 
 const STORAGE_KEY = 'ancient-war-save'
+const AUTOSAVE_INTERVAL = 60_000
+const overlayOrder: OverlayKey[] = ['political', 'stability', 'economic']
+const overlayTranslationKeys: Record<OverlayKey, TranslationKey> = {
+  political: 'overlays.map.political',
+  stability: 'overlays.map.stability',
+  economic: 'overlays.map.economic',
+}
+
+type SaveMode = 'manual' | 'auto' | 'quick'
 
 function App() {
-  const { state, initialise, performAction, endTurn, setSelectedTerritory, saveGame, loadGameFromPayload } =
-    useGameEngine()
+  const { state, initialise, performAction, endTurn, setSelectedTerritory, saveGame, loadGameFromPayload } = useGameEngine()
+  const { theme, setTheme, colorPalette, setColorPalette, tooltipDepth, setTooltipDepth } = useSettings()
+  const { t, locale, setLocale } = useTranslation()
   const [pendingAction, setPendingAction] = useState<ActionType | null>(null)
-  const [mapMode, setMapMode] = useState<'political' | 'stability'>('political')
+  const [overlay, setOverlay] = useState<OverlayKey>('political')
+  const [systemNotifications, setSystemNotifications] = useState<NotificationEntry[]>([])
+  const [lastSaveTimestamp, setLastSaveTimestamp] = useState<number | undefined>()
+  const [turnDurationMs, setTurnDurationMs] = useState(0)
+  const economyRef = useRef<HTMLDivElement | null>(null)
+  const turnStartRef = useRef<number>(performance.now())
+  const notificationTimeouts = useRef<Record<string, number>>({})
 
   const playerNation = state ? state.nations[state.playerNationId] : null
 
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      if (!state || !playerNation) return
-      const key = event.key.toLowerCase()
-      if (key === ACTION_SHORTCUTS.endTurn) {
-        event.preventDefault()
-        endTurn()
-      }
-      if (key === ACTION_SHORTCUTS.toggleMapMode) {
-        event.preventDefault()
-        setMapMode((prev) => (prev === 'political' ? 'stability' : 'political'))
-      }
-      if (key === ACTION_SHORTCUTS.openActions) {
-        event.preventDefault()
-        setPendingAction('InvestInTech')
-      }
-      if (key === ACTION_SHORTCUTS.openDiplomacy) {
-        event.preventDefault()
-        document.getElementById('diplomacy-panel')?.scrollIntoView({ behavior: 'smooth' })
-      }
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [state, playerNation, endTurn])
+  const territories = useMemo(() => (state ? Object.values(state.territories) : []), [state])
+  const nations = useMemo(() => (state ? Object.values(state.nations) : []), [state])
+  const playerTerritories = useMemo(
+    () => territories.filter((territory) => territory.ownerId === state?.playerNationId),
+    [territories, state?.playerNationId],
+  )
 
-  const handleConfirmAction = (action: Parameters<typeof performAction>[0]) => {
-    performAction(action)
-  }
+  const pushSystemNotification = useCallback(
+    (messageKey: Parameters<typeof t>[0], tone: NotificationEntry['tone'] = 'neutral') => {
+      const entry: NotificationEntry = {
+        id: `sys-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        message: t(messageKey),
+        tone,
+        timestamp: Date.now(),
+      }
+      setSystemNotifications((prev) => [...prev.slice(-4), entry])
+      const timeout = window.setTimeout(() => {
+        setSystemNotifications((prev) => prev.filter((item) => item.id !== entry.id))
+      }, 4_000)
+      notificationTimeouts.current[entry.id] = timeout
+    },
+    [t],
+  )
 
-  const handleSave = () => {
-    const payload = saveGame()
-    if (payload) {
-      localStorage.setItem(STORAGE_KEY, payload)
-    }
-  }
+  useEffect(() => () => {
+    Object.values(notificationTimeouts.current).forEach((timeoutId) => window.clearTimeout(timeoutId))
+  }, [])
 
-  const handleLoad = () => {
-    const payload = localStorage.getItem(STORAGE_KEY)
+  const handleSave = useCallback(
+    (mode: SaveMode = 'manual') => {
+      const payload = saveGame()
+      if (!payload) return
+      window.localStorage.setItem(STORAGE_KEY, payload)
+      const now = Date.now()
+      setLastSaveTimestamp(now)
+      const messageKey =
+        mode === 'auto'
+          ? 'notifications.autosave'
+          : mode === 'quick'
+            ? 'notifications.quicksave'
+            : 'notifications.manualsave'
+      pushSystemNotification(messageKey, 'positive')
+    },
+    [pushSystemNotification, saveGame],
+  )
+
+  const handleQuickSave = useCallback(() => {
+    pushSystemNotification('quicksave.prompt')
+    handleSave('quick')
+  }, [handleSave, pushSystemNotification])
+
+  const handleLoad = useCallback(() => {
+    const payload = window.localStorage.getItem(STORAGE_KEY)
     if (payload) {
       loadGameFromPayload(payload)
+      turnStartRef.current = performance.now()
     }
-  }
+  }, [loadGameFromPayload])
 
   useEffect(() => {
-    const payload = localStorage.getItem(STORAGE_KEY)
+    const payload = window.localStorage.getItem(STORAGE_KEY)
     if (payload) {
       loadGameFromPayload(payload)
     }
   }, [loadGameFromPayload])
 
-  const territories = useMemo(() => (state ? Object.values(state.territories) : []), [state])
-  const nations = useMemo(() => (state ? Object.values(state.nations) : []), [state])
+  useEffect(() => {
+    if (!state) return
+    const id = window.setInterval(() => {
+      pushSystemNotification('autosave.prompt')
+      handleSave('auto')
+    }, AUTOSAVE_INTERVAL)
+    return () => window.clearInterval(id)
+  }, [state, handleSave, pushSystemNotification])
+
+  useEffect(() => {
+    if (!state) return
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = t('confirm.quit')
+      return t('confirm.quit')
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [state, t])
+
+  useEffect(() => {
+    if (!state) return
+    const now = performance.now()
+    setTurnDurationMs(now - turnStartRef.current)
+    turnStartRef.current = now
+  }, [state?.turn])
+
+  const cycleOverlay = useCallback(() => {
+    setOverlay((current) => {
+      const nextIndex = (overlayOrder.indexOf(current) + 1) % overlayOrder.length
+      return overlayOrder[nextIndex]
+    })
+  }, [])
+
+  const handleConfirmAction = useCallback(
+    (action: Parameters<typeof performAction>[0]) => {
+      performAction(action)
+    },
+    [performAction],
+  )
+
+  useHotkeys(
+    (action) => {
+      if (!state || !playerNation) return
+      switch (action) {
+        case 'openMenu':
+          setPendingAction('InvestInTech')
+          break
+        case 'toggleMap':
+          cycleOverlay()
+          break
+        case 'endTurn':
+          endTurn()
+          break
+        case 'quickSave':
+          handleQuickSave()
+          break
+        case 'openEconomy':
+          economyRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          break
+        default:
+          break
+      }
+    },
+    { disabled: !state },
+  )
+
+  const combinedNotifications = useMemo(
+    () => [...(state?.notifications ?? []), ...systemNotifications],
+    [state?.notifications, systemNotifications],
+  )
 
   if (!state || !playerNation) {
     return <NationSelect nations={nationDefinitions} onSelect={(nationId) => initialise(nationId)} />
@@ -83,26 +199,74 @@ function App() {
   const actionsRemaining = Math.max(0, gameConfig.maxActionsPerTurn - state.actionsTaken)
 
   return (
-    <div className="app-shell">
-      <NotificationStack notifications={state.notifications} />
-      <main className="app-main">
-        <HUD nation={playerNation} treasury={playerNation.treasury} turn={state.turn} actionsRemaining={actionsRemaining} />
-        <section className="app-content">
-          <div className="map-panel">
+    <div className={`app-shell tooltip-depth-${tooltipDepth}`}>
+      <NotificationStack notifications={combinedNotifications} />
+      <header className="app-toolbar">
+        <div className="app-toolbar__group">
+          <label>
+            {t('settings.theme')}
+            <select value={theme} onChange={(event) => setTheme(event.target.value as ThemeMode)}>
+              <option value="light">{t('settings.theme.light')}</option>
+              <option value="dark">{t('settings.theme.dark')}</option>
+            </select>
+          </label>
+          <label>
+            {t('settings.colorblind')}
+            <select value={colorPalette} onChange={(event) => setColorPalette(event.target.value as ColorPalette)}>
+              <option value="standard">{t('settings.colorblind.standard')}</option>
+              <option value="deuteranopia">{t('settings.colorblind.deuteranopia')}</option>
+              <option value="protanopia">{t('settings.colorblind.protanopia')}</option>
+              <option value="tritanopia">{t('settings.colorblind.tritanopia')}</option>
+            </select>
+          </label>
+          <label>
+            {t('settings.tooltips')}
+            <select value={tooltipDepth} onChange={(event) => setTooltipDepth(event.target.value as 'basic' | 'deep')}>
+              <option value="basic">{t('settings.tooltips.basic')}</option>
+              <option value="deep">{t('settings.tooltips.deep')}</option>
+            </select>
+          </label>
+          <label>
+            {t('settings.language')}
+            <select value={locale} onChange={(event) => setLocale(event.target.value as typeof locale)}>
+              <option value="en">{t('language.en')}</option>
+              <option value="sv-SE">{t('language.sv')}</option>
+            </select>
+          </label>
+        </div>
+        <div className="app-toolbar__group">
+          <button type="button" onClick={() => handleSave('manual')}>
+            {t('app.save')}
+          </button>
+          <button type="button" onClick={handleQuickSave}>
+            {t('app.quickSave')}
+          </button>
+          <button type="button" onClick={handleLoad}>
+            {t('app.load')}
+          </button>
+        </div>
+      </header>
+      <main className="app-layout">
+        <aside className="app-column app-column--left">
+          <ActionMenu actionsRemaining={actionsRemaining} onSelect={(action) => setPendingAction(action)} />
+          <HotkeyManager />
+          <AudioControls />
+          <ScreenshotExporter />
+        </aside>
+        <section className="app-column app-column--center">
+          <HUD nation={playerNation} treasury={playerNation.treasury} turn={state.turn} actionsRemaining={actionsRemaining} />
+          <section className="map-panel">
             <div className="map-panel__header">
-              <h2>Strategic Map</h2>
+              <div>
+                <h2>{t('app.map.strategic')}</h2>
+                <OverlayControls value={overlay} onChange={setOverlay} />
+              </div>
               <div className="map-panel__controls">
-                <button type="button" onClick={() => setMapMode(mapMode === 'political' ? 'stability' : 'political')}>
-                  Toggle Map ({mapMode})
-                </button>
-                <button type="button" onClick={handleSave}>
-                  Save
-                </button>
-                <button type="button" onClick={handleLoad}>
-                  Load
+                <button type="button" onClick={cycleOverlay}>
+                  {t('app.toggleMap')} ({t(overlayTranslationKeys[overlay])})
                 </button>
                 <button type="button" onClick={endTurn}>
-                  End Turn (E)
+                  {t('app.endTurn')}
                 </button>
               </div>
             </div>
@@ -110,18 +274,30 @@ function App() {
               territories={territories}
               nations={state.nations}
               selectedTerritoryId={state.selectedTerritoryId}
-              mode={mapMode}
+              mode={overlay}
               onSelect={(territoryId) => setSelectedTerritory(territoryId)}
             />
-          </div>
-          <aside className="sidebar">
-            <ActionMenu actionsRemaining={actionsRemaining} onSelect={(action) => setPendingAction(action)} />
-            <div id="diplomacy-panel">
-              <DiplomacyPanel playerNation={playerNation} nations={nations} diplomacy={state.diplomacy} />
-            </div>
-          </aside>
+            <MiniMap
+              territories={territories}
+              nations={state.nations}
+              selectedTerritoryId={state.selectedTerritoryId}
+              onSelect={(territoryId) => setSelectedTerritory(territoryId)}
+            />
+          </section>
+          <MissionPanel turn={state.turn} log={state.log} />
+          <PerformanceStats turnDurationMs={turnDurationMs} lastSaveTimestamp={lastSaveTimestamp} />
+          <EventLog entries={state.log} />
         </section>
-        <EventLog entries={state.log} />
+        <aside className="app-column app-column--right">
+          <div ref={economyRef}>
+            <EconomyPanel nation={playerNation} territories={playerTerritories} />
+          </div>
+          <CourtIntriguePanel nation={playerNation} />
+          <TechTree nation={playerNation} />
+          <DiplomacyPanel playerNation={playerNation} nations={nations} diplomacy={state.diplomacy} />
+          <AchievementsPanel state={state} />
+          <HelpCodex />
+        </aside>
       </main>
       {pendingAction && (
         <ActionModal

--- a/frontend/src/components/AchievementsPanel.css
+++ b/frontend/src/components/AchievementsPanel.css
@@ -1,0 +1,37 @@
+.achievements {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.achievements__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.achievements__list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.7rem;
+  background: var(--color-surface-elevated);
+  font-size: 0.9rem;
+}
+
+.achievements__list li.is-unlocked {
+  border: 1px solid var(--color-positive);
+  color: var(--color-positive);
+}
+
+.achievements__list li.is-locked {
+  opacity: 0.6;
+}
+
+.achievements__empty {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/components/AchievementsPanel.tsx
+++ b/frontend/src/components/AchievementsPanel.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react'
+import type { GameState } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
+import type { TranslationKey } from '../i18n/translations'
+import './AchievementsPanel.css'
+
+interface AchievementsPanelProps {
+  state: GameState
+}
+
+type AchievementId = 'first-blood' | 'strategist' | 'master-diplomat'
+
+const achievementTranslationKeys: Record<AchievementId, TranslationKey> = {
+  'first-blood': 'achievements.entry.first-blood',
+  strategist: 'achievements.entry.strategist',
+  'master-diplomat': 'achievements.entry.master-diplomat',
+}
+
+const achievementDefinitions: Array<{ id: AchievementId; threshold: number }> = [
+  { id: 'first-blood', threshold: 1 },
+  { id: 'strategist', threshold: 5 },
+  { id: 'master-diplomat', threshold: 10 },
+]
+
+const AchievementsPanel = ({ state }: AchievementsPanelProps) => {
+  const { t } = useTranslation()
+  const entries = useMemo(() => {
+    return achievementDefinitions.map((definition) => ({
+      id: definition.id,
+      unlocked: state.turn >= definition.threshold,
+    }))
+  }, [state.turn])
+
+  return (
+    <section className="panel achievements" aria-labelledby="achievements-title">
+      <header className="panel__header">
+        <h3 id="achievements-title">{t('achievements.title')}</h3>
+      </header>
+      {entries.length === 0 ? (
+        <p className="achievements__empty">{t('achievements.none')}</p>
+      ) : (
+        <ul className="achievements__list">
+          {entries.map((entry) => (
+            <li key={entry.id} className={entry.unlocked ? 'is-unlocked' : 'is-locked'}>
+              <span>{t(achievementTranslationKeys[entry.id])}</span>
+              <span>{entry.unlocked ? t('achievements.unlocked') : t('achievements.locked')}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default AchievementsPanel

--- a/frontend/src/components/ActionMenu.css
+++ b/frontend/src/components/ActionMenu.css
@@ -1,5 +1,5 @@
 .action-menu {
-  background: var(--surface-panel);
+  background: var(--color-surface);
   border-radius: 1.25rem;
   padding: 1.25rem;
   box-shadow: var(--shadow-subtle);
@@ -15,15 +15,15 @@
   text-transform: uppercase;
   font-size: 0.85rem;
   letter-spacing: 0.12em;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }
 
 .action-menu header span {
-  background: var(--surface-elevated);
+  background: var(--color-surface-elevated);
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
   font-size: 0.75rem;
-  color: var(--text-strong);
+  color: var(--color-text-primary);
 }
 
 .action-menu__grid {
@@ -33,7 +33,7 @@
 }
 
 .action-card {
-  background: var(--surface-elevated);
+  background: var(--color-surface-elevated);
   border: 1px solid transparent;
   border-radius: 1rem;
   padding: 0.75rem;
@@ -58,7 +58,7 @@
   display: grid;
   place-items: center;
   background: linear-gradient(135deg, rgba(118, 138, 166, 0.25), rgba(61, 82, 117, 0.35));
-  color: var(--accent-primary);
+  color: var(--color-accent);
   font-size: 1.4rem;
 }
 
@@ -70,11 +70,11 @@
 
 .action-card__body strong {
   font-size: 0.95rem;
-  color: var(--text-strong);
+  color: var(--color-text-primary);
 }
 
 .action-card__body p {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }

--- a/frontend/src/components/ActionMenu.tsx
+++ b/frontend/src/components/ActionMenu.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import { Lightning, Coins, Scroll, Sword, UsersThree, ShieldCheck, ArrowsCounterClockwise, Handshake, Target, Eye, Barricade } from '@phosphor-icons/react'
 import type { ActionType } from '../game/types'
 import { ACTION_LABELS } from '../game/constants'
+import { useTranslation } from '../contexts/TranslationContext'
 import './ActionMenu.css'
 
 interface ActionMenuProps {
@@ -9,7 +10,7 @@ interface ActionMenuProps {
   actionsRemaining: number
 }
 
-const actionIcons: Record<ActionType, JSX.Element> = {
+const actionIcons: Record<ActionType, ReactNode> = {
   InvestInTech: <Lightning weight="bold" />,
   RecruitArmy: <ShieldCheck weight="bold" />,
   MoveArmy: <ArrowsCounterClockwise weight="bold" />,
@@ -23,28 +24,17 @@ const actionIcons: Record<ActionType, JSX.Element> = {
   SuppressCrime: <Barricade weight="bold" />,
 }
 
-const actionDescriptions: Record<ActionType, string> = {
-  InvestInTech: 'Boost science and technology at the cost of coin.',
-  RecruitArmy: 'Raise fresh troops within a controlled territory.',
-  MoveArmy: 'Redeploy armies or assault a neighboring region.',
-  CollectTaxes: 'Extract revenues and risk growing unrest.',
-  PassLaw: 'Stabilize society through new legislation.',
-  Spy: 'Disrupt an opponent with covert agents.',
-  DiplomacyOffer: 'Improve relations via gifts and emissaries.',
-  DeclareWar: 'Begin open conflict with a rival state.',
-  FormAlliance: 'Bind another nation in mutual defense.',
-  Bribe: 'Influence leaders through clandestine payments.',
-  SuppressCrime: 'Deploy forces internally to lower crime.',
-}
-
 export const ActionMenu = ({ onSelect, actionsRemaining }: ActionMenuProps) => {
+  const { t } = useTranslation()
   const actionList = useMemo(() => Object.keys(ACTION_LABELS) as ActionType[], [])
 
   return (
     <div className="action-menu">
       <header>
-        <h3>Actions</h3>
-        <span>{actionsRemaining} left</span>
+        <h3>{t('actionMenu.title')}</h3>
+        <span>
+          {actionsRemaining} {t('actionMenu.remaining')}
+        </span>
       </header>
       <div className="action-menu__grid">
         {actionList.map((actionType) => (
@@ -56,8 +46,8 @@ export const ActionMenu = ({ onSelect, actionsRemaining }: ActionMenuProps) => {
           >
             <div className="action-card__icon">{actionIcons[actionType]}</div>
             <div className="action-card__body">
-              <strong>{ACTION_LABELS[actionType]}</strong>
-              <p>{actionDescriptions[actionType]}</p>
+              <strong>{t(`actions.label.${actionType}` as const)}</strong>
+              <p>{t(`actions.description.${actionType}` as const)}</p>
             </div>
           </button>
         ))}

--- a/frontend/src/components/ActionModal.tsx
+++ b/frontend/src/components/ActionModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ActionType, NationState, PlayerAction, TerritoryState } from '../game/types'
-import { ACTION_LABELS } from '../game/constants'
+import { useTranslation } from '../contexts/TranslationContext'
 import './ActionModal.css'
 
 interface ActionModalProps {
@@ -16,35 +16,6 @@ interface ActionModalProps {
 const needsTargetNation: ActionType[] = ['Spy', 'DiplomacyOffer', 'DeclareWar', 'FormAlliance', 'Bribe']
 const needsSourceTerritory: ActionType[] = ['RecruitArmy', 'MoveArmy']
 
-const describeEffect = (action: ActionType): string => {
-  switch (action) {
-    case 'InvestInTech':
-      return 'Spend coin to gain technology and science.'
-    case 'RecruitArmy':
-      return 'Raise garrison strength in the selected territory.'
-    case 'MoveArmy':
-      return 'Shift troops to friendly lands or attack adjacent enemies.'
-    case 'CollectTaxes':
-      return 'Gain treasury income, but crime will rise.'
-    case 'PassLaw':
-      return 'Improve laws and stability, with cultural side effects.'
-    case 'Spy':
-      return 'Destabilise a rival and raise their crime.'
-    case 'DiplomacyOffer':
-      return 'Improve relations; special bonuses for maritime deals.'
-    case 'DeclareWar':
-      return 'Begin open conflict. Stability will drop.'
-    case 'FormAlliance':
-      return 'Form a mutual defense pact and boost relations.'
-    case 'Bribe':
-      return 'Buy influence at the cost of coin and their integrity.'
-    case 'SuppressCrime':
-      return 'Reduce crime but lose a little support.'
-    default:
-      return ''
-  }
-}
-
 export const ActionModal = ({
   actionType,
   onClose,
@@ -54,6 +25,7 @@ export const ActionModal = ({
   playerNationId,
   selectedTerritoryId,
 }: ActionModalProps) => {
+  const { t } = useTranslation()
   const [targetNationId, setTargetNationId] = useState<string>('')
   const [sourceTerritoryId, setSourceTerritoryId] = useState<string | undefined>(selectedTerritoryId)
   const [targetTerritoryId, setTargetTerritoryId] = useState<string>('')
@@ -110,21 +82,21 @@ export const ActionModal = ({
     <div className="action-modal__backdrop" role="dialog" aria-modal>
       <div className="action-modal">
         <header>
-          <h3>{ACTION_LABELS[actionType]}</h3>
-          <button type="button" onClick={onClose} aria-label="Close action dialog">
+          <h3>{t(`actions.label.${actionType}` as const)}</h3>
+          <button type="button" onClick={onClose} aria-label={t('help.close')}>
             ✕
           </button>
         </header>
-        <p className="action-modal__description">{describeEffect(actionType)}</p>
+        <p className="action-modal__description">{t(`actions.description.${actionType}` as const)}</p>
 
         {requiresSource && (
           <label className="action-modal__field">
-            <span>Source Territory</span>
+            <span>{t('actions.sourceTerritory')}</span>
             <select
               value={sourceTerritoryId ?? ''}
               onChange={(event) => setSourceTerritoryId(event.target.value || undefined)}
             >
-              <option value="">Select territory</option>
+              <option value="">{t('actions.selectTerritory')}</option>
               {controlledTerritories.map((territory) => (
                 <option key={territory.id} value={territory.id}>
                   {territory.name}
@@ -136,12 +108,15 @@ export const ActionModal = ({
 
         {requiresTargetTerritory && (
           <label className="action-modal__field">
-            <span>Target Territory</span>
+            <span>{t('actions.targetTerritory')}</span>
             <select value={targetTerritoryId} onChange={(event) => setTargetTerritoryId(event.target.value)}>
-              <option value="">Select target</option>
+              <option value="">{t('actions.selectTarget')}</option>
               {neighborOptions.map((territory) => (
                 <option key={territory.id} value={territory.id}>
-                  {territory.name} — {territory.ownerId === playerNationId ? 'Friendly' : 'Enemy'}
+                  {territory.name} —{' '}
+                  {territory.ownerId === playerNationId
+                    ? t('actions.ownership.friendly')
+                    : t('actions.ownership.enemy')}
                 </option>
               ))}
             </select>
@@ -150,9 +125,9 @@ export const ActionModal = ({
 
         {requiresNation && (
           <label className="action-modal__field">
-            <span>Target Nation</span>
+            <span>{t('actions.targetNation')}</span>
             <select value={targetNationId} onChange={(event) => setTargetNationId(event.target.value)}>
-              <option value="">Choose nation</option>
+              <option value="">{t('actions.chooseNation')}</option>
               {availableNationTargets.map((nation) => (
                 <option key={nation.id} value={nation.id}>
                   {nation.name}
@@ -164,10 +139,10 @@ export const ActionModal = ({
 
         <footer>
           <button type="button" className="secondary" onClick={onClose}>
-            Cancel
+            {t('actionModal.cancel')}
           </button>
           <button type="button" onClick={confirm} disabled={!canConfirm()}>
-            Confirm
+            {t('actionModal.confirm')}
           </button>
         </footer>
       </div>

--- a/frontend/src/components/AudioControls.css
+++ b/frontend/src/components/AudioControls.css
@@ -1,0 +1,40 @@
+.audio-controls {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.audio-controls__status {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.audio-controls__buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.audio-controls__buttons button,
+.audio-controls__back {
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.audio-controls__slider {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.audio-controls__slider input[type='range'] {
+  accent-color: var(--color-accent);
+}

--- a/frontend/src/components/AudioControls.tsx
+++ b/frontend/src/components/AudioControls.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react'
+import { useSettings } from '../contexts/SettingsContext'
+import { useTranslation } from '../contexts/TranslationContext'
+import './AudioControls.css'
+
+const TRACK_ID = 'audio.track.ancientEchoes'
+
+const AudioControls = () => {
+  const { audioVolume, setAudioVolume, isAudioMuted, toggleMute } = useSettings()
+  const { t } = useTranslation()
+  const [isPlaying, setIsPlaying] = useState(false)
+  const audioContextRef = useRef<AudioContext | null>(null)
+  const gainNodeRef = useRef<GainNode | null>(null)
+  const oscillatorRef = useRef<OscillatorNode | null>(null)
+
+  useEffect(() => {
+    const context = audioContextRef.current
+    const gain = gainNodeRef.current
+    if (context && gain) {
+      gain.gain.value = isAudioMuted ? 0 : audioVolume
+    }
+  }, [audioVolume, isAudioMuted])
+
+  useEffect(() => () => {
+    oscillatorRef.current?.stop()
+    oscillatorRef.current?.disconnect()
+    gainNodeRef.current?.disconnect()
+    audioContextRef.current?.close()
+  }, [])
+
+  const ensureContext = async () => {
+    if (!audioContextRef.current) {
+      audioContextRef.current = new AudioContext()
+      gainNodeRef.current = audioContextRef.current.createGain()
+      gainNodeRef.current.connect(audioContextRef.current.destination)
+    }
+    if (audioContextRef.current.state === 'suspended') {
+      await audioContextRef.current.resume()
+    }
+  }
+
+  const startPlayback = async () => {
+    await ensureContext()
+    const context = audioContextRef.current
+    const gain = gainNodeRef.current
+    if (!context || !gain) return
+    const oscillator = context.createOscillator()
+    oscillator.type = 'triangle'
+    oscillator.frequency.value = 220
+    oscillator.connect(gain)
+    oscillator.start()
+    oscillatorRef.current = oscillator
+    gain.gain.value = isAudioMuted ? 0 : audioVolume
+    setIsPlaying(true)
+  }
+
+  const stopPlayback = () => {
+    oscillatorRef.current?.stop()
+    oscillatorRef.current = null
+    setIsPlaying(false)
+  }
+
+  return (
+    <section className="panel audio-controls" aria-labelledby="audio-controls-title">
+      <header className="panel__header">
+        <h3 id="audio-controls-title">{t('settings.audio')}</h3>
+      </header>
+      <div className="audio-controls__status">
+        <p>
+          {t('audio.nowPlaying')}: <strong>{isPlaying ? t(TRACK_ID) : '—'}</strong>
+        </p>
+        <div className="audio-controls__buttons">
+          <button type="button" onClick={() => (isPlaying ? stopPlayback() : startPlayback())}>
+            {isPlaying ? t('settings.audio.mute') : t('settings.audio.unmute')}
+          </button>
+          <button type="button" onClick={() => toggleMute()}>
+            {isAudioMuted ? t('settings.audio.unmute') : t('settings.audio.mute')}
+          </button>
+        </div>
+      </div>
+      <label className="audio-controls__slider">
+        <span>{t('settings.audio.volume')}</span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={audioVolume}
+          onChange={(event) => setAudioVolume(Number(event.target.value))}
+        />
+      </label>
+    </section>
+  )
+}
+
+export default AudioControls

--- a/frontend/src/components/CourtIntriguePanel.css
+++ b/frontend/src/components/CourtIntriguePanel.css
@@ -1,0 +1,50 @@
+.court-panel {
+  display: grid;
+  gap: 1rem;
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.court-panel__list {
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+}
+
+.court-panel__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.court-panel__meta {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.court-panel__risk {
+  position: relative;
+  width: 6rem;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: var(--color-surface-elevated);
+  overflow: hidden;
+}
+
+.court-panel__risk span {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, var(--color-warning), transparent);
+  transition: width 0.4s ease;
+}
+
+.court-panel__empty {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}

--- a/frontend/src/components/CourtIntriguePanel.tsx
+++ b/frontend/src/components/CourtIntriguePanel.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from 'react'
+import type { NationState } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
+import Tooltip from './Tooltip'
+import './CourtIntriguePanel.css'
+
+interface CourtIntriguePanelProps {
+  nation: NationState
+}
+
+const factionNames = ['Senate', 'Merchant Guild', 'War Council', 'Scholars']
+
+const CourtIntriguePanel = ({ nation }: CourtIntriguePanelProps) => {
+  const { t } = useTranslation()
+  const factions = useMemo(() => {
+    if (!nation.stats.influence) return []
+    return factionNames.map((name, index) => ({
+      id: name,
+      influence: Math.max(10, (nation.stats.influence ?? 0) - index * 5),
+      risk: Math.min(100, 30 + index * 12),
+    }))
+  }, [nation.stats.influence])
+
+  return (
+    <section className="panel court-panel" aria-labelledby="court-panel-title">
+      <header className="panel__header">
+        <h3 id="court-panel-title">{t('court.title')}</h3>
+      </header>
+      {factions.length === 0 ? (
+        <p className="court-panel__empty">{t('court.noFactions')}</p>
+      ) : (
+        <ul className="court-panel__list">
+          {factions.map((faction) => (
+            <li key={faction.id} className="court-panel__item">
+              <div>
+                <strong>{faction.id}</strong>
+                <p className="court-panel__meta">
+                  {t('court.influence')}: {faction.influence}%
+                </p>
+              </div>
+              <Tooltip
+                align="right"
+                content={
+                  <p>
+                    {t('court.risks')}: {faction.risk}% — {t('court.influence')}: {faction.influence}%
+                  </p>
+                }
+              >
+                <div className="court-panel__risk" aria-label={`${t('court.risks')} ${faction.risk}%`}>
+                  <span style={{ width: `${faction.risk}%` }} />
+                </div>
+              </Tooltip>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default CourtIntriguePanel

--- a/frontend/src/components/DiplomacyPanel.css
+++ b/frontend/src/components/DiplomacyPanel.css
@@ -1,5 +1,5 @@
 .diplomacy-panel {
-  background: var(--surface-panel);
+  background: var(--color-surface);
   border-radius: 1.25rem;
   padding: 1.25rem;
   box-shadow: var(--shadow-subtle);
@@ -14,7 +14,7 @@
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 0.85rem;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }
 
 .diplomacy-panel ul {
@@ -34,20 +34,20 @@
   gap: 1rem;
   padding: 0.85rem 1rem;
   border-radius: 1rem;
-  background: var(--surface-elevated);
+  background: var(--color-surface-elevated);
   border: 1px solid transparent;
 }
 
 .diplomacy-row strong {
   display: block;
-  color: var(--text-strong);
+  color: var(--color-text-primary);
   font-size: 0.95rem;
 }
 
 .diplomacy-row span {
   display: block;
   font-size: 0.75rem;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }
 
 .diplomacy-row__status {
@@ -61,7 +61,7 @@
   font-size: 1rem;
   padding: 0.2rem 0.6rem;
   border-radius: 0.75rem;
-  background: var(--surface-panel);
+  background: var(--color-surface);
 }
 
 .diplomacy-row--ally {

--- a/frontend/src/components/DiplomacyPanel.tsx
+++ b/frontend/src/components/DiplomacyPanel.tsx
@@ -1,4 +1,5 @@
 import type { DiplomacyMatrix, NationState } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
 import './DiplomacyPanel.css'
 
 interface DiplomacyPanelProps {
@@ -13,34 +14,37 @@ const relationTone = (score: number): 'ally' | 'neutral' | 'hostile' => {
   return 'neutral'
 }
 
-export const DiplomacyPanel = ({ playerNation, nations, diplomacy }: DiplomacyPanelProps) => (
-  <div className="diplomacy-panel">
-    <h3>Diplomacy</h3>
-    <ul>
-      {nations
-        .filter((nation) => nation.id !== playerNation.id)
-        .map((nation) => {
-          const score = diplomacy.relations[playerNation.id]?.[nation.id] ?? 0
-          const tone = relationTone(score)
-          const key = [playerNation.id, nation.id].sort().join('|')
-          const atWar = diplomacy.wars.has(key)
-          const allied = diplomacy.alliances.has(key)
-          return (
-            <li key={nation.id} className={`diplomacy-row diplomacy-row--${tone}`}>
-              <div>
-                <strong>{nation.name}</strong>
-                <span>{nation.description}</span>
-              </div>
-              <div className="diplomacy-row__status">
-                <span className="diplomacy-score">{score}</span>
-                {atWar && <span className="tag tag--war">War</span>}
-                {allied && <span className="tag tag--ally">Alliance</span>}
-              </div>
-            </li>
-          )
-        })}
-    </ul>
-  </div>
-)
+export const DiplomacyPanel = ({ playerNation, nations, diplomacy }: DiplomacyPanelProps) => {
+  const { t } = useTranslation()
+  return (
+    <div className="diplomacy-panel">
+      <h3>{t('diplomacy.title')}</h3>
+      <ul>
+        {nations
+          .filter((nation) => nation.id !== playerNation.id)
+          .map((nation) => {
+            const score = diplomacy.relations[playerNation.id]?.[nation.id] ?? 0
+            const tone = relationTone(score)
+            const key = [playerNation.id, nation.id].sort().join('|')
+            const atWar = diplomacy.wars.has(key)
+            const allied = diplomacy.alliances.has(key)
+            return (
+              <li key={nation.id} className={`diplomacy-row diplomacy-row--${tone}`}>
+                <div>
+                  <strong>{nation.name}</strong>
+                  <span>{nation.description}</span>
+                </div>
+                <div className="diplomacy-row__status">
+                  <span className="diplomacy-score">{score}</span>
+                  {atWar && <span className="tag tag--war">{t('diplomacy.status.war')}</span>}
+                  {allied && <span className="tag tag--ally">{t('diplomacy.status.alliance')}</span>}
+                </div>
+              </li>
+            )
+          })}
+      </ul>
+    </div>
+  )
+}
 
 export default DiplomacyPanel

--- a/frontend/src/components/EconomyPanel.css
+++ b/frontend/src/components/EconomyPanel.css
@@ -1,0 +1,84 @@
+.economy-panel {
+  display: grid;
+  gap: 1rem;
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.economy-panel:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
+}
+
+.economy-panel__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.economy-panel__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.economy-panel__label {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.economy-panel__value {
+  font-size: 1.4rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.economy-panel__balance {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.economy-panel__balance--positive {
+  background: linear-gradient(135deg, var(--color-positive), transparent);
+}
+
+.economy-panel__balance--negative {
+  background: linear-gradient(135deg, var(--color-negative), transparent);
+}
+
+.economy-panel__routes ul {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.economy-panel__routes li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  background: var(--color-surface-elevated);
+}
+
+.economy-panel__empty {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1100px) {
+  .economy-panel__grid {
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  }
+}

--- a/frontend/src/components/EconomyPanel.tsx
+++ b/frontend/src/components/EconomyPanel.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react'
+import type { NationState, TerritoryState } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
+import Tooltip from './Tooltip'
+import './EconomyPanel.css'
+
+interface EconomyPanelProps {
+  nation: NationState
+  territories: TerritoryState[]
+}
+
+const EconomyPanel = ({ nation, territories }: EconomyPanelProps) => {
+  const { t } = useTranslation()
+  const tradeRoutes = useMemo(() => {
+    const totalRoutes = territories.reduce((sum, territory) => sum + territory.neighbors.length, 0)
+    const coastal = territories.filter((territory) => territory.terrain === 'coastal').length
+    return {
+      total: totalRoutes,
+      maritime: coastal,
+      land: totalRoutes - coastal,
+    }
+  }, [territories])
+
+  const economyScore = nation.stats.economy ?? 0
+  const upkeep = nation.armies.length * 5
+  const income = economyScore * 8 + territories.length * 3
+  const balance = income - upkeep
+
+  return (
+    <section className="panel economy-panel" aria-labelledby="economy-panel-title">
+      <header className="panel__header">
+        <h3 id="economy-panel-title">{t('economy.title')}</h3>
+      </header>
+      <div className="economy-panel__grid">
+        <div className="economy-panel__stat">
+          <Tooltip
+            content={
+              <p>
+                {t('economy.income')} {income.toFixed(1)} — {t('economy.expenses')} {upkeep.toFixed(1)}
+              </p>
+            }
+          >
+            <span className="economy-panel__label">{t('economy.income')}</span>
+            <strong className="economy-panel__value">{income.toFixed(1)}</strong>
+          </Tooltip>
+        </div>
+        <div className="economy-panel__stat">
+          <Tooltip
+            content={
+              <p>
+                {t('economy.expenses')} {upkeep.toFixed(1)} — {t('economy.trade.agreements')} {tradeRoutes.total}
+              </p>
+            }
+          >
+            <span className="economy-panel__label">{t('economy.expenses')}</span>
+            <strong className="economy-panel__value">{upkeep.toFixed(1)}</strong>
+          </Tooltip>
+        </div>
+        <div className={`economy-panel__balance economy-panel__balance--${balance >= 0 ? 'positive' : 'negative'}`}>
+          <span>{balance >= 0 ? '+' : '−'}</span>
+          <strong>{Math.abs(balance).toFixed(1)}</strong>
+        </div>
+      </div>
+      <div className="economy-panel__routes">
+        <h4>{t('economy.tradeRoutes')}</h4>
+        {tradeRoutes.total === 0 ? (
+          <p className="economy-panel__empty">{t('economy.noRoutes')}</p>
+        ) : (
+          <ul>
+            <li>
+              <span>{t('economy.trade.agreements')}</span>
+              <strong>{tradeRoutes.total}</strong>
+            </li>
+            <li>
+              <span>{t('economy.trade.maritime')}</span>
+              <strong>{tradeRoutes.maritime}</strong>
+            </li>
+            <li>
+              <span>{t('economy.trade.land')}</span>
+              <strong>{tradeRoutes.land}</strong>
+            </li>
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default EconomyPanel

--- a/frontend/src/components/EventLog.css
+++ b/frontend/src/components/EventLog.css
@@ -1,5 +1,5 @@
 .event-log {
-  background: var(--surface-panel);
+  background: var(--color-surface);
   border-radius: 1.25rem;
   padding: 1.25rem;
   box-shadow: var(--shadow-subtle);
@@ -13,7 +13,7 @@
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-size: 0.85rem;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }
 
 .event-log__items {
@@ -28,7 +28,7 @@
 .event-log__item {
   border-radius: 0.9rem;
   padding: 0.85rem 1rem;
-  background: var(--surface-elevated);
+  background: var(--color-surface-elevated);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -41,18 +41,18 @@
 
 .event-log__item header span {
   font-size: 0.75rem;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }
 
 .event-log__item header strong {
   font-size: 0.95rem;
-  color: var(--text-strong);
+  color: var(--color-text-primary);
 }
 
 .event-log__item p {
   margin: 0.5rem 0 0;
   font-size: 0.8rem;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }
 
 .event-log__item--success {
@@ -65,4 +65,9 @@
 
 .event-log__item--danger {
   border: 1px solid rgba(255, 107, 99, 0.25);
+}
+
+.event-log__empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
 }

--- a/frontend/src/components/EventLog.tsx
+++ b/frontend/src/components/EventLog.tsx
@@ -1,25 +1,36 @@
 import type { TurnLogEntry } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
 import './EventLog.css'
 
 interface EventLogProps {
   entries: TurnLogEntry[]
 }
 
-export const EventLog = ({ entries }: EventLogProps) => (
-  <div className="event-log">
-    <h3>Chronicles</h3>
-    <div className="event-log__items">
-      {entries.slice(0, 10).map((entry) => (
-        <article key={entry.id} className={`event-log__item event-log__item--${entry.tone}`}>
-          <header>
-            <span>Turn {entry.turn}</span>
-            <strong>{entry.summary}</strong>
-          </header>
-          {entry.details && <p>{entry.details}</p>}
-        </article>
-      ))}
+export const EventLog = ({ entries }: EventLogProps) => {
+  const { t } = useTranslation()
+  const latest = entries.slice(0, 10)
+  return (
+    <div className="event-log">
+      <h3>{t('eventLog.title')}</h3>
+      <div className="event-log__items">
+        {latest.length === 0 ? (
+          <p className="event-log__empty">{t('eventLog.empty')}</p>
+        ) : (
+          latest.map((entry) => (
+            <article key={entry.id} className={`event-log__item event-log__item--${entry.tone}`}>
+              <header>
+                <span>
+                  {t('app.turn')} {entry.turn}
+                </span>
+                <strong>{entry.summary}</strong>
+              </header>
+              {entry.details && <p>{entry.details}</p>}
+            </article>
+          ))
+        )}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 export default EventLog

--- a/frontend/src/components/HUD.css
+++ b/frontend/src/components/HUD.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  background: var(--surface-panel);
+  background: var(--color-surface);
   border-radius: 1.5rem;
   padding: 1.5rem;
   box-shadow: var(--shadow-soft);
@@ -18,12 +18,12 @@
 .hud__header h1 {
   margin: 0;
   font-size: 1.8rem;
-  color: var(--text-strong);
+  color: var(--color-text-primary);
 }
 
 .hud__header p {
   margin: 0.35rem 0 0;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
   line-height: 1.6;
 }
 
@@ -31,11 +31,11 @@
   display: flex;
   gap: 0.75rem;
   font-size: 0.85rem;
-  background: var(--surface-elevated);
+  background: var(--color-surface-elevated);
   padding: 0.75rem 1rem;
   border-radius: 1rem;
   align-items: center;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
 }
 
 .hud__stats {

--- a/frontend/src/components/HUD.tsx
+++ b/frontend/src/components/HUD.tsx
@@ -1,4 +1,6 @@
-import type { NationState } from '../game/types'
+import type { NationState, StatKey } from '../game/types'
+import type { TranslationKey } from '../i18n/translations'
+import { useTranslation } from '../contexts/TranslationContext'
 import StatBar from './StatBar'
 import './HUD.css'
 
@@ -9,17 +11,17 @@ interface HUDProps {
   actionsRemaining: number
 }
 
-const statConfig = [
-  { key: 'stability', label: 'Stability' },
-  { key: 'military', label: 'Military' },
-  { key: 'tech', label: 'Technology' },
-  { key: 'economy', label: 'Economy' },
-  { key: 'crime', label: 'Crime', invert: true },
-  { key: 'influence', label: 'Influence' },
-  { key: 'support', label: 'Support' },
-  { key: 'science', label: 'Science' },
-  { key: 'laws', label: 'Laws' },
-] as const
+const statConfig: Array<{ key: StatKey; translation: TranslationKey; invert?: boolean }> = [
+  { key: 'stability', translation: 'stats.stability' },
+  { key: 'military', translation: 'stats.military' },
+  { key: 'tech', translation: 'stats.tech' },
+  { key: 'economy', translation: 'stats.economy' },
+  { key: 'crime', translation: 'stats.crime', invert: true },
+  { key: 'influence', translation: 'stats.influence' },
+  { key: 'support', translation: 'stats.support' },
+  { key: 'science', translation: 'stats.science' },
+  { key: 'laws', translation: 'stats.laws' },
+]
 
 const toneFor = (value: number, invert?: boolean) => {
   if (invert) {
@@ -32,30 +34,39 @@ const toneFor = (value: number, invert?: boolean) => {
   return 'critical'
 }
 
-export const HUD = ({ nation, treasury, turn, actionsRemaining }: HUDProps) => (
-  <section className="hud">
-    <header className="hud__header">
-      <div>
-        <h1>{nation.name}</h1>
-        <p>{nation.description}</p>
+export const HUD = ({ nation, treasury, turn, actionsRemaining }: HUDProps) => {
+  const { t } = useTranslation()
+  return (
+    <section className="hud">
+      <header className="hud__header">
+        <div>
+          <h1>{nation.name}</h1>
+          <p>{nation.description}</p>
+        </div>
+        <div className="hud__meta">
+          <span>
+            {t('app.turn')} {turn}
+          </span>
+          <span>
+            {t('app.treasury')} {treasury}
+          </span>
+          <span>
+            {t('hud.actionsLeft')} {actionsRemaining}
+          </span>
+        </div>
+      </header>
+      <div className="hud__stats">
+        {statConfig.map((stat) => (
+          <StatBar
+            key={stat.key}
+            label={t(stat.translation)}
+            value={nation.stats[stat.key]}
+            tone={toneFor(nation.stats[stat.key], stat.invert) as any}
+          />
+        ))}
       </div>
-      <div className="hud__meta">
-        <span>Turn {turn}</span>
-        <span>Treasury {treasury}</span>
-        <span>Actions left {actionsRemaining}</span>
-      </div>
-    </header>
-    <div className="hud__stats">
-      {statConfig.map((stat) => (
-        <StatBar
-          key={stat.key}
-          label={stat.label}
-          value={nation.stats[stat.key]}
-          tone={toneFor(nation.stats[stat.key], stat.invert) as any}
-        />
-      ))}
-    </div>
-  </section>
-)
+    </section>
+  )
+}
 
 export default HUD

--- a/frontend/src/components/HelpCodex.css
+++ b/frontend/src/components/HelpCodex.css
@@ -1,0 +1,88 @@
+.help-codex {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.help-codex__layout {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) 2fr;
+  gap: 1rem;
+}
+
+.help-codex__sidebar {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.help-codex__sidebar input {
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+}
+
+.help-codex__sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.help-codex__sidebar button {
+  width: 100%;
+  text-align: left;
+  border: none;
+  padding: 0.5rem 0.6rem;
+  border-radius: 0.6rem;
+  background: transparent;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.help-codex__sidebar button.is-active,
+.help-codex__sidebar button:hover {
+  background: linear-gradient(135deg, var(--color-highlight), transparent);
+}
+
+.help-codex__content {
+  background: var(--color-surface-elevated);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.help-codex__section {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+.help-codex__back {
+  justify-self: start;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.help-codex__empty {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 900px) {
+  .help-codex__layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/HelpCodex.tsx
+++ b/frontend/src/components/HelpCodex.tsx
@@ -1,0 +1,121 @@
+import { useMemo, useState } from 'react'
+import { useTranslation } from '../contexts/TranslationContext'
+import type { TranslationKey } from '../i18n/translations'
+import './HelpCodex.css'
+
+interface CodexEntry {
+  id: string
+  section: 'economy' | 'military' | 'politics' | 'technology' | 'diplomacy'
+  titleKey: TranslationKey
+  bodyKey: TranslationKey
+}
+
+const entries: CodexEntry[] = [
+  {
+    id: 'economy-1',
+    section: 'economy',
+    titleKey: 'codex.entry.tradeEfficiency.title',
+    bodyKey: 'codex.entry.tradeEfficiency.body',
+  },
+  {
+    id: 'military-1',
+    section: 'military',
+    titleKey: 'codex.entry.armyComposition.title',
+    bodyKey: 'codex.entry.armyComposition.body',
+  },
+  {
+    id: 'politics-1',
+    section: 'politics',
+    titleKey: 'codex.entry.senateSupport.title',
+    bodyKey: 'codex.entry.senateSupport.body',
+  },
+  {
+    id: 'technology-1',
+    section: 'technology',
+    titleKey: 'codex.entry.researchPriorities.title',
+    bodyKey: 'codex.entry.researchPriorities.body',
+  },
+  {
+    id: 'diplomacy-1',
+    section: 'diplomacy',
+    titleKey: 'codex.entry.allianceWeb.title',
+    bodyKey: 'codex.entry.allianceWeb.body',
+  },
+]
+
+const HelpCodex = () => {
+  const { t } = useTranslation()
+  const [query, setQuery] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(entries[0]?.id ?? null)
+
+  const localisedEntries = useMemo(
+    () =>
+      entries.map((entry) => ({
+        ...entry,
+        title: t(entry.titleKey as Parameters<typeof t>[0]),
+        body: t(entry.bodyKey as Parameters<typeof t>[0]),
+      })),
+    [t],
+  )
+
+  const filteredEntries = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    if (!normalized) return localisedEntries
+    return localisedEntries.filter(
+      (entry) => entry.title.toLowerCase().includes(normalized) || entry.body.toLowerCase().includes(normalized),
+    )
+  }, [query, localisedEntries])
+
+  const visibleSelected = filteredEntries.find((entry) => entry.id === selectedId) ?? filteredEntries[0] ?? null
+
+  return (
+    <section className="panel help-codex" aria-labelledby="help-codex-title">
+      <header className="panel__header">
+        <h3 id="help-codex-title">{t('codex.title')}</h3>
+      </header>
+      <div className="help-codex__layout">
+        <aside className="help-codex__sidebar">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t('codex.searchPlaceholder')}
+            aria-label={t('codex.searchPlaceholder')}
+          />
+          <nav>
+            <ul>
+              {filteredEntries.map((entry) => (
+                <li key={entry.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedId(entry.id)}
+                    className={visibleSelected?.id === entry.id ? 'is-active' : ''}
+                  >
+                    {t(`codex.section.${entry.section}` as const)} — {entry.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </aside>
+        <article className="help-codex__content">
+          {visibleSelected ? (
+            <>
+              <header>
+                <p className="help-codex__section">{t(`codex.section.${visibleSelected.section}` as const)}</p>
+                <h4>{visibleSelected.title}</h4>
+              </header>
+              <p>{visibleSelected.body}</p>
+              <button type="button" onClick={() => setSelectedId(null)} className="help-codex__back">
+                {t('codex.back')}
+              </button>
+            </>
+          ) : (
+            <p className="help-codex__empty">{t('achievements.none')}</p>
+          )}
+        </article>
+      </div>
+    </section>
+  )
+}
+
+export default HelpCodex

--- a/frontend/src/components/HotkeyManager.css
+++ b/frontend/src/components/HotkeyManager.css
@@ -1,0 +1,39 @@
+.hotkey-manager {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.hotkey-manager__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.hotkey-manager__list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  background: var(--color-surface-elevated);
+  border-radius: 0.6rem;
+  padding: 0.5rem 0.6rem;
+}
+
+.hotkey-manager__list button {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+}
+
+.hotkey-manager__list button.is-pending {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 35%, transparent);
+}

--- a/frontend/src/components/HotkeyManager.tsx
+++ b/frontend/src/components/HotkeyManager.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react'
+import { useSettings, type HotkeyAction } from '../contexts/SettingsContext'
+import { useTranslation } from '../contexts/TranslationContext'
+import './HotkeyManager.css'
+
+const actionOrder: HotkeyAction[] = ['openMenu', 'toggleMap', 'endTurn', 'quickSave', 'openEconomy']
+
+const HotkeyManager = () => {
+  const { hotkeys, setHotkey } = useSettings()
+  const { t } = useTranslation()
+  const [pending, setPending] = useState<HotkeyAction | null>(null)
+
+  const handleStartRebind = useCallback((action: HotkeyAction) => {
+    setPending(action)
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!pending) return
+      event.preventDefault()
+      const key = event.key.toLowerCase()
+      setHotkey(pending, key)
+      setPending(null)
+    },
+    [pending, setHotkey],
+  )
+
+  return (
+    <section className="panel hotkey-manager" aria-labelledby="hotkey-manager-title">
+      <header className="panel__header">
+        <h3 id="hotkey-manager-title">{t('settings.hotkeys')}</h3>
+      </header>
+      <ul className="hotkey-manager__list">
+        {actionOrder.map((action) => (
+          <li key={action}>
+            <span>{t(`hotkeys.${action}` as const)}</span>
+            <button
+              type="button"
+              onClick={() => handleStartRebind(action)}
+              onKeyDown={handleKeyDown}
+              className={pending === action ? 'is-pending' : ''}
+            >
+              {pending === action ? t('settings.hotkey.press') : hotkeys[action].toUpperCase()}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default HotkeyManager

--- a/frontend/src/components/MapBoard.css
+++ b/frontend/src/components/MapBoard.css
@@ -14,16 +14,43 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  color: #0b1320;
+  color: var(--color-map-text, #0b1320);
   font-size: 0.75rem;
   text-align: left;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--tile-color, #889) 75%, transparent), var(--tile-color, #889));
+  border-color: color-mix(in srgb, var(--tile-color, #889) 70%, black 5%);
 }
 
-.map-tile:hover {
+.map-board--stability .map-tile {
+  background: linear-gradient(
+    135deg,
+    rgba(88, 134, 255, calc(var(--stability-opacity, 0.6))),
+    rgba(59, 84, 182, calc(var(--stability-opacity, 0.6) + 0.15))
+  );
+  color: #f0f4ff;
+}
+
+.map-board--economic .map-tile {
+  background: radial-gradient(
+      circle at top,
+      rgba(242, 185, 80, calc(var(--economic-strength, 0.4))),
+      transparent 60%
+    ),
+    linear-gradient(135deg, color-mix(in srgb, var(--tile-color, #889) 65%, black 15%), var(--tile-color, #889));
+  border-color: color-mix(in srgb, var(--tile-color, #889) 50%, black 20%);
+}
+
+.map-tile:hover,
+.map-tile:focus-visible {
   transform: translateY(-4px);
   box-shadow: 0 14px 28px rgba(12, 18, 30, 0.25);
+}
+
+.map-tile:focus-visible {
+  outline: 3px solid var(--color-highlight);
+  outline-offset: 2px;
 }
 
 .map-tile--selected {
@@ -32,7 +59,7 @@
 
 .map-tile__name {
   font-weight: 700;
-  font-size: 0.85rem;
+  font-size: clamp(0.75rem, 0.7rem + 0.3vw, 0.9rem);
 }
 
 .map-tile__owner {
@@ -49,10 +76,7 @@
   color: rgba(15, 18, 27, 0.8);
 }
 
-.map-board--stability .map-tile {
-  color: #f0f4ff;
-}
-
-.map-board--stability .map-tile__meta {
-  color: rgba(255, 255, 255, 0.7);
+.map-board--stability .map-tile__meta,
+.map-board--economic .map-tile__meta {
+  color: rgba(255, 255, 255, 0.85);
 }

--- a/frontend/src/components/MapBoard.tsx
+++ b/frontend/src/components/MapBoard.tsx
@@ -1,4 +1,6 @@
+import type { CSSProperties } from 'react'
 import type { NationState, TerritoryState } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
 import './MapBoard.css'
 
 interface MapBoardProps {
@@ -6,52 +8,52 @@ interface MapBoardProps {
   nations: Record<string, NationState>
   selectedTerritoryId?: string
   onSelect: (territoryId: string) => void
-  mode: 'political' | 'stability'
+  mode: 'political' | 'stability' | 'economic'
 }
 
-const nationPalette: Record<string, string> = {
-  rome: '#f25d52',
-  carthage: '#f2b950',
-  egypt: '#f2d479',
-  minoa: '#6fc2ff',
-  hittites: '#b77cf2',
-  assyria: '#ff8ab5',
-  akkad: '#ff9a62',
-  medes: '#8bd88f',
-  harappa: '#4ec9b0',
-  shang: '#8aa5ff',
-  scythia: '#4c90ff',
-}
+type CSSCustomProperties = CSSProperties & Record<`--${string}`, string | number>
 
 export const MapBoard = ({ territories, nations, selectedTerritoryId, onSelect, mode }: MapBoardProps) => {
+  const { t } = useTranslation()
   const rows = Math.max(...territories.map((territory) => territory.coordinates[0])) + 1
   const cols = Math.max(...territories.map((territory) => territory.coordinates[1])) + 1
 
+  const boardStyle: CSSProperties = {
+    gridTemplateRows: `repeat(${rows}, 1fr)`,
+    gridTemplateColumns: `repeat(${cols}, 1fr)`,
+  }
+
   return (
-    <div className={`map-board map-board--${mode}`} style={{ gridTemplateRows: `repeat(${rows}, 1fr)`, gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
+    <div className={`map-board map-board--${mode}`} style={boardStyle}>
       {territories.map((territory) => {
         const nation = nations[territory.ownerId]
-        const color = nationPalette[territory.ownerId] ?? '#888'
         const stability = nation?.stats.stability ?? 50
         const stabilityOpacity = Math.min(0.85, Math.max(0.25, stability / 120))
+        const development = Math.min(100, Math.max(0, territory.development))
+        const tileStyle: CSSCustomProperties = {
+          gridRow: territory.coordinates[0] + 1,
+          gridColumn: territory.coordinates[1] + 1,
+          '--tile-color': `var(--nation-${territory.ownerId ?? 'neutral'})`,
+          '--stability-opacity': stabilityOpacity,
+          '--economic-strength': development / 100,
+        }
         return (
           <button
             key={territory.id}
             type="button"
             className={`map-tile ${selectedTerritoryId === territory.id ? 'map-tile--selected' : ''}`}
-            style={{
-              gridRow: territory.coordinates[0] + 1,
-              gridColumn: territory.coordinates[1] + 1,
-              background: mode === 'political' ? `linear-gradient(135deg, ${color}aa, ${color})` : `linear-gradient(135deg, rgba(88, 134, 255, ${stabilityOpacity}), rgba(59, 84, 182, ${stabilityOpacity + 0.15}))`,
-              borderColor: color,
-            }}
+            style={tileStyle}
             onClick={() => onSelect(territory.id)}
           >
             <span className="map-tile__name">{territory.name}</span>
-            <span className="map-tile__owner">{nation?.name ?? 'Unclaimed'}</span>
+            <span className="map-tile__owner">{nation?.name ?? t('map.unclaimed')}</span>
             <div className="map-tile__meta">
-              <span>Garrison {territory.garrison}</span>
-              <span>Dev {territory.development}</span>
+              <span>
+                {t('map.garrison')} {territory.garrison}
+              </span>
+              <span>
+                {t('map.development')} {territory.development}
+              </span>
             </div>
           </button>
         )

--- a/frontend/src/components/MiniMap.css
+++ b/frontend/src/components/MiniMap.css
@@ -1,0 +1,38 @@
+.minimap {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.minimap__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(1.5rem, 1fr));
+  gap: 0.3rem;
+  max-height: 10rem;
+  overflow: auto;
+  padding: 0.25rem;
+  border-radius: 0.75rem;
+  background: var(--color-surface-elevated);
+}
+
+.minimap__cell {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background: var(--owner-color, var(--color-surface));
+  border: none;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.minimap__cell:hover,
+.minimap__cell:focus-visible {
+  transform: translateY(-1px) scale(1.05);
+  box-shadow: 0 0 0 2px var(--color-accent);
+}
+
+.minimap__cell.is-selected {
+  box-shadow: 0 0 0 2px var(--color-highlight);
+}

--- a/frontend/src/components/MiniMap.tsx
+++ b/frontend/src/components/MiniMap.tsx
@@ -1,0 +1,43 @@
+import type { CSSProperties } from 'react'
+import type { NationState, TerritoryState } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
+import './MiniMap.css'
+
+interface MiniMapProps {
+  territories: TerritoryState[]
+  nations: Record<string, NationState>
+  selectedTerritoryId?: string
+  onSelect: (territoryId: string) => void
+}
+
+const MiniMap = ({ territories, nations, selectedTerritoryId, onSelect }: MiniMapProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <section className="panel minimap" aria-labelledby="minimap-title">
+      <header className="panel__header">
+        <h3 id="minimap-title">{t('minimap.title')}</h3>
+      </header>
+      <div className="minimap__grid" role="list">
+        {territories.map((territory) => {
+          const owner = nations[territory.ownerId]
+          return (
+            <button
+              type="button"
+              key={territory.id}
+              className={`minimap__cell ${territory.id === selectedTerritoryId ? 'is-selected' : ''}`}
+              style={{
+                '--owner-color': `var(--nation-${owner?.id ?? 'neutral'})`,
+              } as CSSProperties}
+              onClick={() => onSelect(territory.id)}
+            >
+              <span className="sr-only">{territory.name}</span>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default MiniMap

--- a/frontend/src/components/MissionPanel.css
+++ b/frontend/src/components/MissionPanel.css
@@ -1,0 +1,31 @@
+.mission-panel {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.mission-panel__section ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.mission-panel__section li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 0.6rem;
+  background: var(--color-surface-elevated);
+}
+
+.mission-panel__empty {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/components/MissionPanel.tsx
+++ b/frontend/src/components/MissionPanel.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react'
+import type { TurnLogEntry } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
+import './MissionPanel.css'
+
+interface MissionPanelProps {
+  turn: number
+  log: TurnLogEntry[]
+}
+
+const MissionPanel = ({ turn, log }: MissionPanelProps) => {
+  const { t } = useTranslation()
+  const missions = useMemo(() => {
+    const active = log.slice(-3).map((entry) => ({
+      id: entry.id,
+      title: entry.summary,
+      status: 'active' as const,
+      turnAssigned: entry.turn,
+    }))
+    if (active.length === 0) {
+      return { active: [], completed: [] as typeof active }
+    }
+    const completed = active.filter((mission) => mission.turnAssigned < turn - 2)
+    const current = active.filter((mission) => mission.turnAssigned >= turn - 2)
+    return { active: current, completed }
+  }, [log, turn])
+
+  return (
+    <section className="panel mission-panel" aria-labelledby="mission-panel-title">
+      <header className="panel__header">
+        <h3 id="mission-panel-title">{t('missions.title')}</h3>
+      </header>
+      <div className="mission-panel__section">
+        <h4>{t('missions.active')}</h4>
+        {missions.active.length === 0 ? (
+          <p className="mission-panel__empty">{t('missions.none')}</p>
+        ) : (
+          <ul>
+            {missions.active.map((mission) => (
+              <li key={mission.id}>
+                <strong>{mission.title}</strong>
+                <span>
+                  {t('app.turn')} {mission.turnAssigned}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="mission-panel__section">
+        <h4>{t('missions.completed')}</h4>
+        {missions.completed.length === 0 ? (
+          <p className="mission-panel__empty">{t('missions.none')}</p>
+        ) : (
+          <ul>
+            {missions.completed.map((mission) => (
+              <li key={mission.id}>
+                <strong>{mission.title}</strong>
+                <span>{t('missions.completed')}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default MissionPanel

--- a/frontend/src/components/NationSelect.tsx
+++ b/frontend/src/components/NationSelect.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import type { NationDefinition } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
 import './NationSelect.css'
 
 interface NationSelectProps {
@@ -8,14 +9,15 @@ interface NationSelectProps {
 }
 
 export const NationSelect = ({ nations, onSelect }: NationSelectProps) => {
+  const { t } = useTranslation()
   const [hoveredNation, setHoveredNation] = useState<string | null>(null)
   const orderedNations = useMemo(() => nations.slice().sort((a, b) => a.name.localeCompare(b.name)), [nations])
 
   return (
     <div className="nation-select">
       <header>
-        <h1>Choose Your Civilization</h1>
-        <p>Select a legendary nation to guide through intrigue, warfare, and diplomacy.</p>
+        <h1>{t('nationSelect.title')}</h1>
+        <p>{t('nationSelect.subtitle')}</p>
       </header>
       <div className="nation-select__grid">
         {orderedNations.map((nation) => (
@@ -32,19 +34,23 @@ export const NationSelect = ({ nations, onSelect }: NationSelectProps) => {
               <h2>{nation.name}</h2>
               <p>{nation.description}</p>
               <div className="nation-card__tags">
-                <span>{nation.territories.length} territories</span>
-                <span>Stability {nation.stats.stability}</span>
+                <span>
+                  {nation.territories.length} {t('nationSelect.territories')}
+                </span>
+                <span>
+                  {t('nationSelect.stabilityLabel')} {nation.stats.stability}
+                </span>
               </div>
             </div>
             {hoveredNation === nation.id && (
               <div className="nation-card__tooltip">
-                <strong>Advantages</strong>
+                <strong>{t('nationSelect.advantages')}</strong>
                 <ul>
                   {nation.advantages.map((advantage) => (
                     <li key={advantage}>{advantage}</li>
                   ))}
                 </ul>
-                <strong>Disadvantages</strong>
+                <strong>{t('nationSelect.disadvantages')}</strong>
                 <ul>
                   {nation.disadvantages.map((disadvantage) => (
                     <li key={disadvantage}>{disadvantage}</li>

--- a/frontend/src/components/OverlayControls.css
+++ b/frontend/src/components/OverlayControls.css
@@ -1,0 +1,37 @@
+.overlay-controls {
+  border: none;
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+  min-inline-size: 0;
+}
+
+.overlay-controls legend {
+  font-weight: 600;
+}
+
+.overlay-controls__options {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.overlay-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.6rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.overlay-controls label.is-active {
+  background: linear-gradient(135deg, var(--color-accent), transparent);
+  transform: translateX(0.2rem);
+}
+
+.overlay-controls input {
+  accent-color: var(--color-accent);
+}

--- a/frontend/src/components/OverlayControls.tsx
+++ b/frontend/src/components/OverlayControls.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from '../contexts/TranslationContext'
+import Tooltip from './Tooltip'
+import './OverlayControls.css'
+
+type OverlayKey = 'political' | 'stability' | 'economic'
+
+interface OverlayControlsProps {
+  value: OverlayKey
+  onChange: (overlay: OverlayKey) => void
+}
+
+const OverlayControls = ({ value, onChange }: OverlayControlsProps) => {
+  const { t } = useTranslation()
+  const overlays: OverlayKey[] = ['political', 'stability', 'economic']
+
+  return (
+    <fieldset className="overlay-controls">
+      <legend>{t('overlays.title')}</legend>
+      <div className="overlay-controls__options">
+        {overlays.map((overlay) => (
+          <label key={overlay} className={value === overlay ? 'is-active' : ''}>
+            <input
+              type="radio"
+              name="map-overlay"
+              value={overlay}
+              checked={value === overlay}
+              onChange={() => onChange(overlay)}
+            />
+            <Tooltip
+              content={
+                <div>
+                  <strong>{t(`overlays.map.${overlay}` as const)}</strong>
+                  <p>{t('overlays.select')}</p>
+                </div>
+              }
+            >
+              <span>{t(`overlays.map.${overlay}` as const)}</span>
+            </Tooltip>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}
+
+export type { OverlayKey }
+export default OverlayControls

--- a/frontend/src/components/PerformanceStats.css
+++ b/frontend/src/components/PerformanceStats.css
@@ -1,0 +1,23 @@
+.performance {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.performance__metrics {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.performance__metrics li {
+  display: flex;
+  justify-content: space-between;
+  background: var(--color-surface-elevated);
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+}

--- a/frontend/src/components/PerformanceStats.tsx
+++ b/frontend/src/components/PerformanceStats.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from '../contexts/TranslationContext'
+import './PerformanceStats.css'
+
+interface PerformanceStatsProps {
+  turnDurationMs: number
+  lastSaveTimestamp?: number
+}
+
+const PerformanceStats = ({ turnDurationMs, lastSaveTimestamp }: PerformanceStatsProps) => {
+  const { t } = useTranslation()
+  const [fps, setFps] = useState(0)
+  const frameCount = useRef(0)
+  const lastTime = useRef(performance.now())
+
+  useEffect(() => {
+    let frameId: number
+    const loop = (time: number) => {
+      frameCount.current += 1
+      const delta = time - lastTime.current
+      if (delta >= 1000) {
+        setFps(Math.round((frameCount.current * 1000) / delta))
+        frameCount.current = 0
+        lastTime.current = time
+      }
+      frameId = requestAnimationFrame(loop)
+    }
+    frameId = requestAnimationFrame(loop)
+    return () => cancelAnimationFrame(frameId)
+  }, [])
+
+  const lastSave = lastSaveTimestamp ? new Date(lastSaveTimestamp).toLocaleTimeString() : '—'
+
+  return (
+    <section className="panel performance" aria-labelledby="performance-title">
+      <header className="panel__header">
+        <h3 id="performance-title">{t('performance.title')}</h3>
+      </header>
+      <ul className="performance__metrics">
+        <li>
+          <span>{t('performance.fps')}</span>
+          <strong>{fps}</strong>
+        </li>
+        <li>
+          <span>{t('performance.turnTime')}</span>
+          <strong>{turnDurationMs.toFixed(0)} ms</strong>
+        </li>
+        <li>
+          <span>{t('performance.lastSave')}</span>
+          <strong>{lastSave}</strong>
+        </li>
+      </ul>
+    </section>
+  )
+}
+
+export default PerformanceStats

--- a/frontend/src/components/ScreenshotExporter.css
+++ b/frontend/src/components/ScreenshotExporter.css
@@ -1,0 +1,28 @@
+.screenshot-exporter {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.screenshot-exporter button {
+  justify-self: start;
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, var(--color-accent), transparent);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.screenshot-exporter button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.screenshot-exporter__error {
+  font-size: 0.8rem;
+  color: var(--color-negative);
+}

--- a/frontend/src/components/ScreenshotExporter.tsx
+++ b/frontend/src/components/ScreenshotExporter.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { toPng } from 'html-to-image'
+import { useTranslation } from '../contexts/TranslationContext'
+import './ScreenshotExporter.css'
+
+const ScreenshotExporter = () => {
+  const { t } = useTranslation()
+  const [isCapturing, setCapturing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleCapture = async () => {
+    const target = document.querySelector('.app-shell') as HTMLElement | null
+    if (!target) return
+    try {
+      setCapturing(true)
+      setError(null)
+      const dataUrl = await toPng(target, {
+        cacheBust: true,
+        pixelRatio: window.devicePixelRatio * 1.2,
+      })
+      const link = document.createElement('a')
+      link.download = `ancient-war-${Date.now()}.png`
+      link.href = dataUrl
+      link.click()
+    } catch (captureError) {
+      setError((captureError as Error).message)
+    } finally {
+      setCapturing(false)
+    }
+  }
+
+  return (
+    <section className="panel screenshot-exporter" aria-labelledby="screenshot-exporter-title">
+      <header className="panel__header">
+        <h3 id="screenshot-exporter-title">{t('screenshot.title')}</h3>
+      </header>
+      <button type="button" onClick={handleCapture} disabled={isCapturing}>
+        {isCapturing ? t('autosave.prompt') : t('screenshot.capture')}
+      </button>
+      {error && <p className="screenshot-exporter__error">{error}</p>}
+    </section>
+  )
+}
+
+export default ScreenshotExporter

--- a/frontend/src/components/StatBar.css
+++ b/frontend/src/components/StatBar.css
@@ -8,19 +8,19 @@
   display: flex;
   justify-content: space-between;
   font-size: 0.85rem;
-  color: var(--text-muted);
+  color: var(--color-text-secondary);
   letter-spacing: 0.05em;
 }
 
 .stat-bar__label strong {
-  color: var(--text-strong);
+  color: var(--color-text-primary);
 }
 
 .stat-bar__meter {
   width: 100%;
   height: 0.6rem;
   border-radius: 999px;
-  background: var(--surface-elevated);
+  background: var(--color-surface-elevated);
   overflow: hidden;
 }
 

--- a/frontend/src/components/StatBar.tsx
+++ b/frontend/src/components/StatBar.tsx
@@ -7,9 +7,9 @@ interface StatBarProps {
 }
 
 const toneColors: Record<NonNullable<StatBarProps['tone']>, string> = {
-  stable: 'var(--accent-positive)',
-  risky: 'var(--accent-warning)',
-  critical: 'var(--accent-danger)',
+  stable: 'var(--color-positive)',
+  risky: 'var(--color-warning)',
+  critical: 'var(--color-negative)',
 }
 
 export const StatBar = ({ label, value, tone = 'stable' }: StatBarProps) => (

--- a/frontend/src/components/TechTree.css
+++ b/frontend/src/components/TechTree.css
@@ -1,0 +1,54 @@
+.tech-tree {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.tech-tree__branches {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tech-tree__branch {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.tech-tree__branch.is-complete strong {
+  color: var(--color-positive);
+}
+
+.tech-tree__branchHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.tech-tree__branchHeader span {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.tech-tree__progress {
+  position: relative;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--color-surface-elevated);
+  overflow: hidden;
+}
+
+.tech-tree__progress span {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, var(--color-accent), transparent);
+  transition: width 0.4s ease;
+}
+
+.tech-tree__empty {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/components/TechTree.tsx
+++ b/frontend/src/components/TechTree.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react'
+import type { NationState } from '../game/types'
+import { useTranslation } from '../contexts/TranslationContext'
+import Tooltip from './Tooltip'
+import './TechTree.css'
+
+interface TechTreeProps {
+  nation: NationState
+}
+
+const TECHNOLOGY_BRANCHES = ['Engineering', 'Strategy', 'Civic', 'Alchemy']
+
+const TechTree = ({ nation }: TechTreeProps) => {
+  const { t } = useTranslation()
+  const techLevel = nation.stats.tech ?? 0
+  const projects = useMemo(() => {
+    if (techLevel === 0) return []
+    return TECHNOLOGY_BRANCHES.map((branch, index) => ({
+      id: branch,
+      progress: Math.min(100, techLevel * 15 - index * 10),
+      completed: techLevel * 15 > 100 + index * 20,
+    }))
+  }, [techLevel])
+
+  return (
+    <section className="panel tech-tree" aria-labelledby="tech-tree-title">
+      <header className="panel__header">
+        <h3 id="tech-tree-title">{t('tech.title')}</h3>
+      </header>
+      {projects.length === 0 ? (
+        <p className="tech-tree__empty">{t('tech.none')}</p>
+      ) : (
+        <ul className="tech-tree__branches">
+          {projects.map((project) => (
+            <li key={project.id} className={`tech-tree__branch ${project.completed ? 'is-complete' : ''}`}>
+              <div className="tech-tree__branchHeader">
+                <strong>{project.id}</strong>
+                <span>{project.completed ? t('tech.completed') : t('tech.progress')}</span>
+              </div>
+              <Tooltip
+                content={
+                  <p>
+                    {t('tech.progress')}: {Math.max(0, Math.min(100, project.progress)).toFixed(0)}%
+                  </p>
+                }
+              >
+                <div className="tech-tree__progress" aria-label={`${project.id} ${project.progress}%`}>
+                  <span style={{ width: `${Math.max(0, Math.min(100, project.progress))}%` }} />
+                </div>
+              </Tooltip>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default TechTree

--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -1,0 +1,48 @@
+.tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.tooltip__bubble {
+  position: absolute;
+  inset-block-start: 100%;
+  inset-inline-start: 0;
+  transform: translateY(0.25rem);
+  width: max-content;
+  max-width: min(24rem, 70vw);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  z-index: 15;
+}
+
+.tooltip:hover .tooltip__bubble,
+.tooltip:focus-within .tooltip__bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0.1rem);
+}
+
+.tooltip--right .tooltip__bubble {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+}
+
+@media (max-width: 900px) {
+  .tooltip__bubble {
+    position: fixed;
+    inset-inline: 1rem;
+    inset-block-end: 1rem;
+    inset-block-start: auto;
+    transform: translateY(0);
+  }
+}

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren, ReactNode } from 'react'
+import './Tooltip.css'
+
+interface TooltipProps {
+  content: ReactNode
+  align?: 'left' | 'right'
+}
+
+const Tooltip = ({ children, content, align = 'left' }: PropsWithChildren<TooltipProps>) => (
+  <span className={`tooltip tooltip--${align}`}>
+    {children}
+    <span className="tooltip__bubble">{content}</span>
+  </span>
+)
+
+export default Tooltip

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -1,0 +1,126 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+
+export type ThemeMode = 'light' | 'dark'
+export type ColorPalette = 'standard' | 'deuteranopia' | 'protanopia' | 'tritanopia'
+export type HotkeyAction = 'openMenu' | 'toggleMap' | 'endTurn' | 'quickSave' | 'openEconomy'
+
+interface SettingsContextValue {
+  theme: ThemeMode
+  colorPalette: ColorPalette
+  hotkeys: Record<HotkeyAction, string>
+  tooltipDepth: 'basic' | 'deep'
+  audioVolume: number
+  isAudioMuted: boolean
+  setTheme: (theme: ThemeMode) => void
+  setColorPalette: (palette: ColorPalette) => void
+  setHotkey: (action: HotkeyAction, key: string) => void
+  setTooltipDepth: (depth: 'basic' | 'deep') => void
+  setAudioVolume: (volume: number) => void
+  toggleMute: () => void
+}
+
+const DEFAULT_SETTINGS: Omit<SettingsContextValue, 'setTheme' | 'setColorPalette' | 'setHotkey' | 'setTooltipDepth' | 'setAudioVolume' | 'toggleMute'> = {
+  theme: 'dark',
+  colorPalette: 'standard',
+  hotkeys: {
+    openMenu: 'a',
+    toggleMap: 'm',
+    endTurn: 'e',
+    quickSave: 'f5',
+    openEconomy: 'f1',
+  },
+  tooltipDepth: 'deep',
+  audioVolume: 0.5,
+  isAudioMuted: false,
+}
+
+const STORAGE_KEY = 'ancient-war-settings'
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
+
+type PersistedSettings = {
+  theme: ThemeMode
+  colorPalette: ColorPalette
+  hotkeys: Record<HotkeyAction, string>
+  tooltipDepth: 'basic' | 'deep'
+  audioVolume: number
+  isAudioMuted: boolean
+}
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = useState<PersistedSettings>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as PersistedSettings
+          return { ...DEFAULT_SETTINGS, ...parsed }
+        } catch (error) {
+          console.warn('Failed to parse settings', error)
+        }
+      }
+    }
+    return { ...DEFAULT_SETTINGS }
+  })
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = settings.theme
+  }, [settings.theme])
+
+  useEffect(() => {
+    document.documentElement.dataset.palette = settings.colorPalette
+  }, [settings.colorPalette])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+    }
+  }, [settings])
+
+  const setTheme = useCallback((theme: ThemeMode) => {
+    setSettings((prev) => ({ ...prev, theme }))
+  }, [])
+
+  const setColorPalette = useCallback((colorPalette: ColorPalette) => {
+    setSettings((prev) => ({ ...prev, colorPalette }))
+  }, [])
+
+  const setHotkey = useCallback((action: HotkeyAction, key: string) => {
+    setSettings((prev) => ({ ...prev, hotkeys: { ...prev.hotkeys, [action]: key.toLowerCase() } }))
+  }, [])
+
+  const setTooltipDepth = useCallback((tooltipDepth: 'basic' | 'deep') => {
+    setSettings((prev) => ({ ...prev, tooltipDepth }))
+  }, [])
+
+  const setAudioVolume = useCallback((audioVolume: number) => {
+    setSettings((prev) => ({ ...prev, audioVolume }))
+  }, [])
+
+  const toggleMute = useCallback(() => {
+    setSettings((prev) => ({ ...prev, isAudioMuted: !prev.isAudioMuted }))
+  }, [])
+
+  const value = useMemo<SettingsContextValue>(
+    () => ({
+      ...settings,
+      setTheme,
+      setColorPalette,
+      setHotkey,
+      setTooltipDepth,
+      setAudioVolume,
+      toggleMute,
+    }),
+    [settings, setTheme, setColorPalette, setHotkey, setTooltipDepth, setAudioVolume, toggleMute],
+  )
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext)
+  if (!context) {
+    throw new Error('useSettings must be used within SettingsProvider')
+  }
+  return context
+}

--- a/frontend/src/contexts/TranslationContext.tsx
+++ b/frontend/src/contexts/TranslationContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import { fallbackLocale, translations, type LocaleKey, type TranslationKey } from '../i18n/translations'
+
+interface TranslationContextValue {
+  locale: LocaleKey
+  setLocale: (locale: LocaleKey) => void
+  t: (key: TranslationKey) => string
+}
+
+const TranslationContext = createContext<TranslationContextValue | undefined>(undefined)
+
+const STORAGE_KEY = 'ancient-war-locale'
+
+export const TranslationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [locale, setLocaleState] = useState<LocaleKey>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(STORAGE_KEY) as LocaleKey | null
+      if (stored && stored in translations) {
+        return stored
+      }
+    }
+    return fallbackLocale
+  })
+
+  const setLocale = useCallback((next: LocaleKey) => {
+    setLocaleState(next)
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    }
+  }, [])
+
+  const value = useMemo<TranslationContextValue>(() => {
+    const dictionary = translations[locale] ?? translations[fallbackLocale]
+    const t = (key: TranslationKey) => dictionary[key] ?? translations[fallbackLocale][key]
+    return { locale, setLocale, t }
+  }, [locale, setLocale])
+
+  return <TranslationContext.Provider value={value}>{children}</TranslationContext.Provider>
+}
+
+export const useTranslation = () => {
+  const context = useContext(TranslationContext)
+  if (!context) {
+    throw new Error('useTranslation must be used within TranslationProvider')
+  }
+  return context
+}

--- a/frontend/src/game/ai.ts
+++ b/frontend/src/game/ai.ts
@@ -45,7 +45,7 @@ const considerWarTargets = ({ state, nation, rng }: AIDecisionContext): PlayerAc
   return { type: 'MoveArmy', sourceTerritoryId: targetTile.id, targetTerritoryId: enemy.id }
 }
 
-const defensivePlan = ({ state, nation }: AIDecisionContext): PlayerAction | undefined => {
+const defensivePlan = ({ nation }: AIDecisionContext): PlayerAction | undefined => {
   const worstCrime = nation.stats.crime
   if (worstCrime > 60) {
     return { type: 'SuppressCrime' }

--- a/frontend/src/game/data.ts
+++ b/frontend/src/game/data.ts
@@ -9,9 +9,9 @@ import type {
   TerritoryState,
 } from './types'
 
-export const nations: NationDefinition[] = nationsRaw
-export const territories: TerritoryDefinition[] = territoriesRaw
-export const gameConfig: GameConfig = configRaw
+export const nations: NationDefinition[] = nationsRaw as NationDefinition[]
+export const territories: TerritoryDefinition[] = territoriesRaw as TerritoryDefinition[]
+export const gameConfig: GameConfig = configRaw as GameConfig
 
 export const buildInitialNationState = (definition: NationDefinition): NationState => ({
   ...definition,

--- a/frontend/src/game/engine.ts
+++ b/frontend/src/game/engine.ts
@@ -45,7 +45,7 @@ const UNIQUE_TRAIT_COST_MODIFIERS: Partial<Record<string, Partial<Record<ActionT
 
 export const createInitialGameState = (
   playerNationId: string,
-  seed: number = Date.now(),
+  _seed: number = Date.now(),
 ): GameState => {
   const nationStates: Record<string, NationState> = {}
   nations.forEach((nation) => {

--- a/frontend/src/hooks/useHotkeys.ts
+++ b/frontend/src/hooks/useHotkeys.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { useSettings, type HotkeyAction } from '../contexts/SettingsContext'
+
+type HotkeyHandler = (action: HotkeyAction) => void
+
+type Options = {
+  disabled?: boolean
+}
+
+export const useHotkeys = (handler: HotkeyHandler, options: Options = {}) => {
+  const { hotkeys } = useSettings()
+
+  useEffect(() => {
+    if (options.disabled) return
+    const listener = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase()
+      const action = (Object.keys(hotkeys) as HotkeyAction[]).find((candidate) => hotkeys[candidate] === key)
+      if (!action) return
+      event.preventDefault()
+      handler(action)
+    }
+    window.addEventListener('keydown', listener)
+    return () => window.removeEventListener('keydown', listener)
+  }, [hotkeys, handler, options.disabled])
+}

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -1,0 +1,546 @@
+export type LocaleKey = 'en' | 'sv-SE'
+
+export type TranslationKey =
+  | 'app.title'
+  | 'app.save'
+  | 'app.load'
+  | 'app.endTurn'
+  | 'app.toggleMap'
+  | 'app.quickSave'
+  | 'app.actionsRemaining'
+  | 'app.turn'
+  | 'app.treasury'
+  | 'app.map.political'
+  | 'app.map.stability'
+  | 'app.map.strategic'
+  | 'hud.actions'
+  | 'hud.stability'
+  | 'hud.research'
+  | 'hud.influence'
+  | 'hud.population'
+  | 'hud.overview'
+  | 'hud.actionsLeft'
+  | 'nationSelect.heading'
+  | 'nationSelect.choose'
+  | 'nationSelect.title'
+  | 'nationSelect.subtitle'
+  | 'nationSelect.territories'
+  | 'nationSelect.stabilityLabel'
+  | 'nationSelect.advantages'
+  | 'nationSelect.disadvantages'
+  | 'actionMenu.title'
+  | 'actionMenu.remaining'
+  | 'actionModal.confirm'
+  | 'actionModal.cancel'
+  | 'actions.sourceTerritory'
+  | 'actions.targetTerritory'
+  | 'actions.targetNation'
+  | 'actions.selectTerritory'
+  | 'actions.selectTarget'
+  | 'actions.chooseNation'
+  | 'actions.ownership.friendly'
+  | 'actions.ownership.enemy'
+  | 'diplomacy.title'
+  | 'diplomacy.relationships'
+  | 'diplomacy.status.war'
+  | 'diplomacy.status.alliance'
+  | 'eventLog.title'
+  | 'eventLog.empty'
+  | 'notifications.autosave'
+  | 'notifications.quicksave'
+  | 'notifications.manualsave'
+  | 'settings.theme'
+  | 'settings.colorblind'
+  | 'settings.language'
+  | 'settings.tooltips'
+  | 'settings.tooltips.basic'
+  | 'settings.tooltips.deep'
+  | 'settings.hotkeys'
+  | 'settings.hotkey.rebind'
+  | 'settings.hotkey.press'
+  | 'settings.audio'
+  | 'settings.audio.mute'
+  | 'settings.audio.unmute'
+  | 'settings.audio.volume'
+  | 'economy.title'
+  | 'economy.tradeRoutes'
+  | 'economy.income'
+  | 'economy.expenses'
+  | 'economy.trade.agreements'
+  | 'economy.trade.maritime'
+  | 'economy.trade.land'
+  | 'court.title'
+  | 'court.factions'
+  | 'court.influence'
+  | 'court.risks'
+  | 'tech.title'
+  | 'tech.progress'
+  | 'tech.completed'
+  | 'missions.title'
+  | 'missions.active'
+  | 'missions.completed'
+  | 'overlays.title'
+  | 'overlays.select'
+  | 'minimap.title'
+  | 'achievements.title'
+  | 'achievements.locked'
+  | 'achievements.unlocked'
+  | 'achievements.entry.first-blood'
+  | 'achievements.entry.strategist'
+  | 'achievements.entry.master-diplomat'
+  | 'codex.title'
+  | 'codex.searchPlaceholder'
+  | 'codex.back'
+  | 'codex.section.economy'
+  | 'codex.section.military'
+  | 'codex.section.politics'
+  | 'codex.section.technology'
+  | 'codex.section.diplomacy'
+  | 'codex.entry.tradeEfficiency.title'
+  | 'codex.entry.tradeEfficiency.body'
+  | 'codex.entry.armyComposition.title'
+  | 'codex.entry.armyComposition.body'
+  | 'codex.entry.senateSupport.title'
+  | 'codex.entry.senateSupport.body'
+  | 'codex.entry.researchPriorities.title'
+  | 'codex.entry.researchPriorities.body'
+  | 'codex.entry.allianceWeb.title'
+  | 'codex.entry.allianceWeb.body'
+  | 'screenshot.title'
+  | 'screenshot.capture'
+  | 'performance.title'
+  | 'performance.fps'
+  | 'performance.turnTime'
+  | 'performance.lastSave'
+  | 'confirm.quit'
+  | 'autosave.prompt'
+  | 'quicksave.prompt'
+  | 'overlays.map.political'
+  | 'overlays.map.stability'
+  | 'overlays.map.economic'
+  | 'missions.none'
+  | 'tech.none'
+  | 'economy.noRoutes'
+  | 'court.noFactions'
+  | 'achievements.none'
+  | 'stats.stability'
+  | 'stats.military'
+  | 'stats.tech'
+  | 'stats.economy'
+  | 'stats.crime'
+  | 'stats.influence'
+  | 'stats.support'
+  | 'stats.science'
+  | 'stats.laws'
+  | 'actions.label.InvestInTech'
+  | 'actions.label.RecruitArmy'
+  | 'actions.label.MoveArmy'
+  | 'actions.label.CollectTaxes'
+  | 'actions.label.PassLaw'
+  | 'actions.label.Spy'
+  | 'actions.label.DiplomacyOffer'
+  | 'actions.label.DeclareWar'
+  | 'actions.label.FormAlliance'
+  | 'actions.label.Bribe'
+  | 'actions.label.SuppressCrime'
+  | 'actions.description.InvestInTech'
+  | 'actions.description.RecruitArmy'
+  | 'actions.description.MoveArmy'
+  | 'actions.description.CollectTaxes'
+  | 'actions.description.PassLaw'
+  | 'actions.description.Spy'
+  | 'actions.description.DiplomacyOffer'
+  | 'actions.description.DeclareWar'
+  | 'actions.description.FormAlliance'
+  | 'actions.description.Bribe'
+  | 'actions.description.SuppressCrime'
+  | 'settings.theme.light'
+  | 'settings.theme.dark'
+  | 'settings.colorblind.standard'
+  | 'settings.colorblind.deuteranopia'
+  | 'settings.colorblind.protanopia'
+  | 'settings.colorblind.tritanopia'
+  | 'help.title'
+  | 'help.shortcuts'
+  | 'help.close'
+  | 'hotkeys.openMenu'
+  | 'hotkeys.toggleMap'
+  | 'hotkeys.endTurn'
+  | 'hotkeys.quickSave'
+  | 'hotkeys.openEconomy'
+  | 'audio.nowPlaying'
+  | 'audio.track.ancientEchoes'
+  | 'map.unclaimed'
+  | 'map.garrison'
+  | 'map.development'
+  | 'language.en'
+  | 'language.sv'
+
+export type TranslationDictionary = Record<TranslationKey, string>
+
+export const translations: Record<LocaleKey, TranslationDictionary> = {
+  en: {
+    'app.title': 'Ancient War Command',
+    'app.save': 'Save',
+    'app.load': 'Load',
+    'app.endTurn': 'End Turn',
+    'app.toggleMap': 'Toggle Map',
+    'app.quickSave': 'Quick Save',
+    'app.actionsRemaining': 'Actions Remaining',
+    'app.turn': 'Turn',
+    'app.treasury': 'Treasury',
+    'app.map.political': 'Political',
+    'app.map.stability': 'Stability',
+    'app.map.strategic': 'Strategic Map',
+    'hud.actions': 'Actions',
+    'hud.stability': 'Stability',
+    'hud.research': 'Research',
+    'hud.influence': 'Influence',
+    'hud.population': 'Population',
+    'hud.overview': 'Overview',
+    'hud.actionsLeft': 'Actions left',
+    'nationSelect.heading': 'Choose Your Nation',
+    'nationSelect.choose': 'Select',
+    'nationSelect.title': 'Choose Your Civilization',
+    'nationSelect.subtitle': 'Select a legendary nation to guide through intrigue, warfare, and diplomacy.',
+    'nationSelect.territories': 'Territories',
+    'nationSelect.stabilityLabel': 'Stability',
+    'nationSelect.advantages': 'Advantages',
+    'nationSelect.disadvantages': 'Disadvantages',
+    'actionMenu.title': 'Command Actions',
+    'actionMenu.remaining': 'Remaining',
+    'actionModal.confirm': 'Confirm',
+    'actionModal.cancel': 'Cancel',
+    'actions.sourceTerritory': 'Source Territory',
+    'actions.targetTerritory': 'Target Territory',
+    'actions.targetNation': 'Target Nation',
+    'actions.selectTerritory': 'Select territory',
+    'actions.selectTarget': 'Select target',
+    'actions.chooseNation': 'Choose nation',
+    'actions.ownership.friendly': 'Friendly',
+    'actions.ownership.enemy': 'Enemy',
+    'diplomacy.title': 'Diplomacy Ledger',
+    'diplomacy.relationships': 'Relationships',
+    'diplomacy.status.war': 'War',
+    'diplomacy.status.alliance': 'Alliance',
+    'eventLog.title': 'Event Log',
+    'eventLog.empty': 'No events recorded yet.',
+    'notifications.autosave': 'Game autosaved.',
+    'notifications.quicksave': 'Quick save complete.',
+    'notifications.manualsave': 'Game saved.',
+    'settings.theme': 'Theme',
+    'settings.colorblind': 'Color Palette',
+    'settings.language': 'Language',
+    'settings.tooltips': 'Tooltips',
+    'settings.tooltips.basic': 'Essential',
+    'settings.tooltips.deep': 'Detailed',
+    'settings.hotkeys': 'Hotkeys',
+    'settings.hotkey.rebind': 'Rebind',
+    'settings.hotkey.press': 'Press a key…',
+    'settings.audio': 'Audio',
+    'settings.audio.mute': 'Mute',
+    'settings.audio.unmute': 'Unmute',
+    'settings.audio.volume': 'Volume',
+    'economy.title': 'Economy & Trade',
+    'economy.tradeRoutes': 'Trade Routes',
+    'economy.income': 'Income',
+    'economy.expenses': 'Expenses',
+    'economy.trade.agreements': 'Trade Agreements',
+    'economy.trade.maritime': 'Maritime',
+    'economy.trade.land': 'Land',
+    'court.title': 'Court & Intrigue',
+    'court.factions': 'Court Factions',
+    'court.influence': 'Influence',
+    'court.risks': 'Risks',
+    'tech.title': 'Tech Tree',
+    'tech.progress': 'Research Progress',
+    'tech.completed': 'Completed Discoveries',
+    'missions.title': 'Missions & Objectives',
+    'missions.active': 'Active',
+    'missions.completed': 'Completed',
+    'overlays.title': 'Overlays',
+    'overlays.select': 'Select overlay',
+    'minimap.title': 'Minimap',
+    'achievements.title': 'Achievements',
+    'achievements.locked': 'Locked',
+    'achievements.unlocked': 'Unlocked',
+    'achievements.entry.first-blood': 'First Blood',
+    'achievements.entry.strategist': 'Grand Strategist',
+    'achievements.entry.master-diplomat': 'Master Diplomat',
+    'codex.title': 'War Codex',
+    'codex.searchPlaceholder': 'Search entries…',
+    'codex.back': 'Back',
+    'codex.section.economy': 'Economy',
+    'codex.section.military': 'Military',
+    'codex.section.politics': 'Politics',
+    'codex.section.technology': 'Technology',
+    'codex.section.diplomacy': 'Diplomacy',
+    'codex.entry.tradeEfficiency.title': 'Trade Efficiency',
+    'codex.entry.tradeEfficiency.body':
+      'Improve stability and reduce corruption to unlock lucrative caravans and maritime trade routes.',
+    'codex.entry.armyComposition.title': 'Army Composition',
+    'codex.entry.armyComposition.body':
+      'Balanced forces with combined arms tactics have higher survival and inflict fewer casualties on friendly regions.',
+    'codex.entry.senateSupport.title': 'Senate Support',
+    'codex.entry.senateSupport.body':
+      'Keep influential factions appeased to avoid costly civil unrest and maintain high stability ratings.',
+    'codex.entry.researchPriorities.title': 'Research Priorities',
+    'codex.entry.researchPriorities.body':
+      'Focus research on engineering early to unlock infrastructure bonuses before pivoting to civics.',
+    'codex.entry.allianceWeb.title': 'Alliance Web',
+    'codex.entry.allianceWeb.body':
+      'Chain alliances carefully to avoid entanglements that drag your empire into unwanted wars.',
+    'screenshot.title': 'Screenshot Export',
+    'screenshot.capture': 'Capture',
+    'performance.title': 'Performance',
+    'performance.fps': 'FPS',
+    'performance.turnTime': 'Turn Time',
+    'performance.lastSave': 'Last Save',
+    'confirm.quit': 'Unsaved progress will be lost. Exit anyway?',
+    'autosave.prompt': 'Autosaving…',
+    'quicksave.prompt': 'Quick saving…',
+    'overlays.map.political': 'Political',
+    'overlays.map.stability': 'Stability',
+    'overlays.map.economic': 'Economic',
+    'missions.none': 'No active missions.',
+    'tech.none': 'No research underway.',
+    'economy.noRoutes': 'No trade routes established.',
+    'court.noFactions': 'No notable factions yet.',
+    'achievements.none': 'No achievements yet.',
+    'stats.stability': 'Stability',
+    'stats.military': 'Military',
+    'stats.tech': 'Technology',
+    'stats.economy': 'Economy',
+    'stats.crime': 'Crime',
+    'stats.influence': 'Influence',
+    'stats.support': 'Support',
+    'stats.science': 'Science',
+    'stats.laws': 'Laws',
+    'actions.label.InvestInTech': 'Invest in Technology',
+    'actions.label.RecruitArmy': 'Recruit Army',
+    'actions.label.MoveArmy': 'Move Army',
+    'actions.label.CollectTaxes': 'Collect Taxes',
+    'actions.label.PassLaw': 'Pass Law',
+    'actions.label.Spy': 'Conduct Espionage',
+    'actions.label.DiplomacyOffer': 'Diplomacy Offer',
+    'actions.label.DeclareWar': 'Declare War',
+    'actions.label.FormAlliance': 'Form Alliance',
+    'actions.label.Bribe': 'Bribe Officials',
+    'actions.label.SuppressCrime': 'Suppress Crime',
+    'actions.description.InvestInTech': 'Spend coin to gain technology and science.',
+    'actions.description.RecruitArmy': 'Raise fresh troops within a controlled territory.',
+    'actions.description.MoveArmy': 'Redeploy armies or assault a neighboring region.',
+    'actions.description.CollectTaxes': 'Extract revenues and risk growing unrest.',
+    'actions.description.PassLaw': 'Stabilise society through new legislation.',
+    'actions.description.Spy': 'Disrupt an opponent with covert agents.',
+    'actions.description.DiplomacyOffer': 'Improve relations via gifts and emissaries.',
+    'actions.description.DeclareWar': 'Begin open conflict with a rival state.',
+    'actions.description.FormAlliance': 'Bind another nation in mutual defense.',
+    'actions.description.Bribe': 'Influence leaders through clandestine payments.',
+    'actions.description.SuppressCrime': 'Deploy forces internally to lower crime.',
+    'settings.theme.light': 'Light',
+    'settings.theme.dark': 'Dark',
+    'settings.colorblind.standard': 'Standard',
+    'settings.colorblind.deuteranopia': 'Deuteranopia',
+    'settings.colorblind.protanopia': 'Protanopia',
+    'settings.colorblind.tritanopia': 'Tritanopia',
+    'help.title': 'Command Help',
+    'help.shortcuts': 'Shortcuts',
+    'help.close': 'Close',
+    'hotkeys.openMenu': 'Open Action Menu',
+    'hotkeys.toggleMap': 'Toggle Map Mode',
+    'hotkeys.endTurn': 'End Turn',
+    'hotkeys.quickSave': 'Quick Save',
+    'hotkeys.openEconomy': 'Focus Economy Panel',
+    'audio.nowPlaying': 'Now playing',
+    'audio.track.ancientEchoes': 'Ancient Echoes',
+    'map.unclaimed': 'Unclaimed',
+    'map.garrison': 'Garrison',
+    'map.development': 'Dev',
+    'language.en': 'English',
+    'language.sv': 'Svenska',
+  },
+  'sv-SE': {
+    'app.title': 'Ancient War Command',
+    'app.save': 'Spara',
+    'app.load': 'Ladda',
+    'app.endTurn': 'Avsluta rundan',
+    'app.toggleMap': 'Växla karta',
+    'app.quickSave': 'Snabbspara',
+    'app.actionsRemaining': 'Åtgärder kvar',
+    'app.turn': 'Runda',
+    'app.treasury': 'Statsskatt',
+    'app.map.political': 'Politisk',
+    'app.map.stability': 'Stabilitet',
+    'app.map.strategic': 'Strategisk karta',
+    'hud.actions': 'Åtgärder',
+    'hud.stability': 'Stabilitet',
+    'hud.research': 'Forskning',
+    'hud.influence': 'Inflytande',
+    'hud.population': 'Befolkning',
+    'hud.overview': 'Översikt',
+    'hud.actionsLeft': 'Åtgärder kvar',
+    'nationSelect.heading': 'Välj din nation',
+    'nationSelect.choose': 'Välj',
+    'nationSelect.title': 'Välj din civilisation',
+    'nationSelect.subtitle': 'Välj en legendarisk nation att leda genom intriger, krig och diplomati.',
+    'nationSelect.territories': 'Territorier',
+    'nationSelect.stabilityLabel': 'Stabilitet',
+    'nationSelect.advantages': 'Fördelar',
+    'nationSelect.disadvantages': 'Nackdelar',
+    'actionMenu.title': 'Kommandoåtgärder',
+    'actionMenu.remaining': 'Kvar',
+    'actionModal.confirm': 'Bekräfta',
+    'actionModal.cancel': 'Avbryt',
+    'actions.sourceTerritory': 'Källt territorium',
+    'actions.targetTerritory': 'Målterritorium',
+    'actions.targetNation': 'Målnation',
+    'actions.selectTerritory': 'Välj territorium',
+    'actions.selectTarget': 'Välj mål',
+    'actions.chooseNation': 'Välj nation',
+    'actions.ownership.friendly': 'Vänlig',
+    'actions.ownership.enemy': 'Fientlig',
+    'diplomacy.title': 'Diplomatisk bok',
+    'diplomacy.relationships': 'Relationer',
+    'diplomacy.status.war': 'Krig',
+    'diplomacy.status.alliance': 'Allians',
+    'eventLog.title': 'Händelselogg',
+    'eventLog.empty': 'Inga händelser registrerade ännu.',
+    'notifications.autosave': 'Spelet autosparat.',
+    'notifications.quicksave': 'Snabbsparning klar.',
+    'notifications.manualsave': 'Spelet sparat.',
+    'settings.theme': 'Tema',
+    'settings.colorblind': 'Färgpalett',
+    'settings.language': 'Språk',
+    'settings.tooltips': 'Verktygstips',
+    'settings.tooltips.basic': 'Grundläggande',
+    'settings.tooltips.deep': 'Fördjupade',
+    'settings.hotkeys': 'Snabbtangenter',
+    'settings.hotkey.rebind': 'Ändra',
+    'settings.hotkey.press': 'Tryck på en tangent…',
+    'settings.audio': 'Ljud',
+    'settings.audio.mute': 'Tysta',
+    'settings.audio.unmute': 'Ljud på',
+    'settings.audio.volume': 'Volym',
+    'economy.title': 'Ekonomi & Handel',
+    'economy.tradeRoutes': 'Handelsrutter',
+    'economy.income': 'Inkomster',
+    'economy.expenses': 'Utgifter',
+    'economy.trade.agreements': 'Handelsavtal',
+    'economy.trade.maritime': 'Maritim',
+    'economy.trade.land': 'Landbaserad',
+    'court.title': 'Hov & Intriger',
+    'court.factions': 'Hovfraktioner',
+    'court.influence': 'Inflytande',
+    'court.risks': 'Risker',
+    'tech.title': 'Teknikträd',
+    'tech.progress': 'Forskningsframsteg',
+    'tech.completed': 'Färdiga upptäckter',
+    'missions.title': 'Uppdrag & mål',
+    'missions.active': 'Aktiva',
+    'missions.completed': 'Avklarade',
+    'overlays.title': 'Överlägg',
+    'overlays.select': 'Välj överlägg',
+    'minimap.title': 'Minikarta',
+    'achievements.title': 'Prestationer',
+    'achievements.locked': 'Låst',
+    'achievements.unlocked': 'Upplåst',
+    'achievements.entry.first-blood': 'Första blod',
+    'achievements.entry.strategist': 'Stor strateg',
+    'achievements.entry.master-diplomat': 'Mästerdiplomat',
+    'codex.title': 'Krigskodex',
+    'codex.searchPlaceholder': 'Sök poster…',
+    'codex.back': 'Tillbaka',
+    'codex.section.economy': 'Ekonomi',
+    'codex.section.military': 'Militär',
+    'codex.section.politics': 'Politik',
+    'codex.section.technology': 'Teknologi',
+    'codex.section.diplomacy': 'Diplomati',
+    'codex.entry.tradeEfficiency.title': 'Handelseffektivitet',
+    'codex.entry.tradeEfficiency.body':
+      'Förbättra stabiliteten och minska korruptionen för att öppna lönsamma karavaner och sjöhandelsrutter.',
+    'codex.entry.armyComposition.title': 'Armésammansättning',
+    'codex.entry.armyComposition.body':
+      'Balanserade styrkor med kombinerade vapen överlever längre och minskar förluster i egna provinser.',
+    'codex.entry.senateSupport.title': 'Senatens stöd',
+    'codex.entry.senateSupport.body':
+      'Håll inflytelserika fraktioner nöjda för att undvika dyrt uppror och behålla hög stabilitet.',
+    'codex.entry.researchPriorities.title': 'Forskningsprioriteringar',
+    'codex.entry.researchPriorities.body':
+      'Fokusera forskningen på ingenjörskonst tidigt för att låsa upp infrastrukturbonusar innan du växlar till civila reformer.',
+    'codex.entry.allianceWeb.title': 'Alliansnätverk',
+    'codex.entry.allianceWeb.body':
+      'Knyt allianser varsamt för att undvika förvecklingar som drar riket in i oönskade krig.',
+    'screenshot.title': 'Skärmdumpsexport',
+    'screenshot.capture': 'Fånga',
+    'performance.title': 'Prestanda',
+    'performance.fps': 'FPS',
+    'performance.turnTime': 'Rundtid',
+    'performance.lastSave': 'Senaste sparning',
+    'confirm.quit': 'Osparad framsteg går förlorad. Avsluta ändå?',
+    'autosave.prompt': 'Autosparar…',
+    'quicksave.prompt': 'Snabbsparar…',
+    'overlays.map.political': 'Politisk',
+    'overlays.map.stability': 'Stabilitet',
+    'overlays.map.economic': 'Ekonomisk',
+    'missions.none': 'Inga aktiva uppdrag.',
+    'tech.none': 'Ingen forskning pågår.',
+    'economy.noRoutes': 'Inga handelsrutter etablerade.',
+    'court.noFactions': 'Inga nämnvärda fraktioner ännu.',
+    'achievements.none': 'Inga prestationer ännu.',
+    'stats.stability': 'Stabilitet',
+    'stats.military': 'Militär',
+    'stats.tech': 'Teknologi',
+    'stats.economy': 'Ekonomi',
+    'stats.crime': 'Brottslighet',
+    'stats.influence': 'Inflytande',
+    'stats.support': 'Stöd',
+    'stats.science': 'Vetenskap',
+    'stats.laws': 'Lagar',
+    'actions.label.InvestInTech': 'Investera i teknologi',
+    'actions.label.RecruitArmy': 'Rekrytera armé',
+    'actions.label.MoveArmy': 'Förflytta armé',
+    'actions.label.CollectTaxes': 'Ta upp skatter',
+    'actions.label.PassLaw': 'Stifta lag',
+    'actions.label.Spy': 'Bedriv spionage',
+    'actions.label.DiplomacyOffer': 'Diplomatisk gest',
+    'actions.label.DeclareWar': 'Förklara krig',
+    'actions.label.FormAlliance': 'Forma allians',
+    'actions.label.Bribe': 'Mutor',
+    'actions.label.SuppressCrime': 'Bekämpa brott',
+    'actions.description.InvestInTech': 'Spendera mynt för att öka teknologi och vetenskap.',
+    'actions.description.RecruitArmy': 'Värva trupper i ett kontrollerat territorium.',
+    'actions.description.MoveArmy': 'Omplacera arméer eller angrip grannar.',
+    'actions.description.CollectTaxes': 'Samla in inkomster men riskera oro.',
+    'actions.description.PassLaw': 'Stabilisera samhället med ny lagstiftning.',
+    'actions.description.Spy': 'Stör en rival med hemliga agenter.',
+    'actions.description.DiplomacyOffer': 'Förbättra relationer genom gåvor och sändebud.',
+    'actions.description.DeclareWar': 'Inled öppen konflikt mot en rival.',
+    'actions.description.FormAlliance': 'Slut försvarspakt och stärk relationer.',
+    'actions.description.Bribe': 'Påverka ledare genom hemliga betalningar.',
+    'actions.description.SuppressCrime': 'Sätt in styrkor internt för att minska brott.',
+    'settings.theme.light': 'Ljust',
+    'settings.theme.dark': 'Mörkt',
+    'settings.colorblind.standard': 'Standard',
+    'settings.colorblind.deuteranopia': 'Deuteranopi',
+    'settings.colorblind.protanopia': 'Protanopi',
+    'settings.colorblind.tritanopia': 'Tritanopi',
+    'help.title': 'Kommandohjälp',
+    'help.shortcuts': 'Genvägar',
+    'help.close': 'Stäng',
+    'hotkeys.openMenu': 'Öppna åtgärdsmeny',
+    'hotkeys.toggleMap': 'Växla kartläge',
+    'hotkeys.endTurn': 'Avsluta rundan',
+    'hotkeys.quickSave': 'Snabbspara',
+    'hotkeys.openEconomy': 'Fokusera ekonomipanel',
+    'audio.nowPlaying': 'Spelar nu',
+    'audio.track.ancientEchoes': 'Forntida ekon',
+    'map.unclaimed': 'Ingen ägare',
+    'map.garrison': 'Garnison',
+    'map.development': 'Utv',
+    'language.en': 'Engelska',
+    'language.sv': 'Svenska',
+  },
+}
+
+export const fallbackLocale: LocaleKey = 'en'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,23 +2,84 @@
 
 :root {
   font-family: 'Inter', system-ui, sans-serif;
-  color: #f4f7ff;
-  background: radial-gradient(circle at 20% 20%, #1f2840, #0b101b 70%);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: dark;
 
-  --surface-panel: rgba(18, 26, 40, 0.78);
-  --surface-elevated: rgba(27, 37, 54, 0.72);
-  --accent-primary: #6f8cff;
-  --accent-positive: #4ed2a7;
-  --accent-warning: #f7b84b;
-  --accent-danger: #ff7d73;
-  --text-muted: rgba(204, 214, 235, 0.75);
-  --text-strong: #f8fbff;
-  --shadow-soft: 0 24px 45px rgba(4, 9, 20, 0.45);
-  --shadow-subtle: 0 18px 38px rgba(8, 12, 24, 0.35);
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --color-bg: #06070c;
+  --color-surface: rgba(21, 24, 33, 0.88);
+  --color-surface-elevated: rgba(33, 40, 58, 0.88);
+  --color-text-primary: #f3f5fb;
+  --color-text-secondary: rgba(222, 229, 245, 0.72);
+  --color-border: rgba(102, 116, 150, 0.4);
+  --color-accent: #6f8cff;
+  --color-highlight: #8bb8ff;
+  --color-positive: #4ed2a7;
+  --color-warning: #f7b84b;
+  --color-negative: #ff7d73;
+  --shadow-soft: 0 24px 45px rgba(4, 9, 20, 0.35);
+  --shadow-strong: 0 30px 55px rgba(7, 10, 22, 0.45);
+  --shadow-subtle: 0 14px 28px rgba(8, 10, 18, 0.35);
+  --color-map-text: #0b1320;
+
+  --nation-rome: #f25d52;
+  --nation-carthage: #f2b950;
+  --nation-egypt: #f2d479;
+  --nation-minoa: #6fc2ff;
+  --nation-hittites: #b77cf2;
+  --nation-assyria: #ff8ab5;
+  --nation-akkad: #ff9a62;
+  --nation-medes: #8bd88f;
+  --nation-harappa: #4ec9b0;
+  --nation-shang: #8aa5ff;
+  --nation-scythia: #4c90ff;
+  --nation-neutral: #a5acc4;
+}
+
+[data-theme='light'] {
+  color-scheme: light;
+  --color-bg: #f3f5fb;
+  --color-surface: rgba(255, 255, 255, 0.86);
+  --color-surface-elevated: rgba(255, 255, 255, 0.92);
+  --color-text-primary: #1b1f29;
+  --color-text-secondary: rgba(31, 38, 56, 0.7);
+  --color-border: rgba(61, 72, 95, 0.18);
+  --color-accent: #3344cc;
+  --color-highlight: #5566dd;
+  --color-positive: #1e976c;
+  --color-warning: #d88418;
+  --color-negative: #c03f3a;
+  --shadow-soft: 0 24px 45px rgba(20, 30, 60, 0.16);
+  --shadow-strong: 0 30px 55px rgba(20, 30, 60, 0.25);
+  --shadow-subtle: 0 14px 28px rgba(20, 30, 60, 0.18);
+  --color-map-text: #1a2133;
+}
+
+[data-palette='deuteranopia'] {
+  --color-accent: #728fe2;
+  --color-highlight: #8fb4f4;
+  --color-positive: #64c6c2;
+  --color-warning: #ebb45b;
+  --color-negative: #ed7f76;
+}
+
+[data-palette='protanopia'] {
+  --color-accent: #5a91e6;
+  --color-highlight: #80b2ff;
+  --color-positive: #5cc3ae;
+  --color-warning: #f3c978;
+  --color-negative: #e87b88;
+}
+
+[data-palette='tritanopia'] {
+  --color-accent: #9a78ff;
+  --color-highlight: #b190ff;
+  --color-positive: #50c698;
+  --color-warning: #d39f3a;
+  --color-negative: #f27262;
 }
 
 * {
@@ -28,7 +89,9 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, #151c2f, #090c16 70%);
+  background: radial-gradient(circle at top, rgba(48, 62, 102, 0.35), transparent 55%),
+    var(--color-bg);
+  color: var(--color-text-primary);
 }
 
 a {
@@ -36,6 +99,30 @@ a {
   text-decoration: none;
 }
 
-button {
+button,
+input,
+select {
   font-family: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.tooltip-depth-basic .tooltip__bubble {
+  max-width: 18rem;
+  opacity: 0.85;
+}
+
+.tooltip-depth-deep .tooltip__bubble {
+  max-width: 26rem;
+  opacity: 1;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { SettingsProvider } from './contexts/SettingsContext'
+import { TranslationProvider } from './contexts/TranslationContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SettingsProvider>
+      <TranslationProvider>
+        <App />
+      </TranslationProvider>
+    </SettingsProvider>
   </StrictMode>,
 )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- add economy, court, tech tree, missions, overlay, minimap, achievements, codex, audio, screenshot, and performance UI panels with supporting styles
- introduce settings and translation providers with full en/sv-SE dictionaries, colorblind palettes, and tooltip depth controls
- wire new hotkey/autosave/audio flows and resolve outstanding TypeScript build errors for overlays, achievements, map styling, and data imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfda45985c8322aa41d85166196d9c