### PR TITLE
Add save version metadata and schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ README.md              → you are here
 
 ### Save / load
 
-The **Save** and **Load** buttons in the map header persist the serialized game state into `localStorage` under the key `ancient-war-save`. The load button retrieves it; the last autosave is restored on refresh.
+The **Save** and **Load** buttons in the map header persist the serialized game state into `localStorage` under the key `ancient-war-save`. The loader now embeds a `saveVersion` marker in every payload; when a legacy v1 save is restored the engine backfills new defaults, logs a compatibility warning in the browser console, and upgrades the state to the latest schema before resuming play.
+
+If you mod the JSON data files (`frontend/src/data/*.json` or `frontend/src/config/config.json`), the import layer validates their schema at startup. Any shape mismatches are reported through console warnings so you can correct custom content before launching a campaign.
 
 ### Example Rome JSON entry
 

--- a/frontend/src/game/__tests__/save.test.ts
+++ b/frontend/src/game/__tests__/save.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createInitialGameState } from '../engine'
+import { loadStateFromString, quickSaveState, SAVE_VERSION } from '../save'
+import type { GameState } from '../types'
+
+const toLegacyPayload = (state: GameState): string => {
+  const serialisable = {
+    ...state,
+    diplomacy: {
+      relations: state.diplomacy.relations,
+      wars: Array.from(state.diplomacy.wars),
+      alliances: Array.from(state.diplomacy.alliances),
+    },
+  }
+  delete (serialisable as Partial<GameState>).saveVersion
+  return JSON.stringify(serialisable)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('save system migrations', () => {
+  it('embeds the saveVersion marker in newly created saves', () => {
+    const state = createInitialGameState('rome', 101)
+    const payload = quickSaveState(state)
+    const parsed = JSON.parse(payload)
+
+    expect(parsed.saveVersion).toBe(SAVE_VERSION)
+  })
+
+  it('upgrades legacy v1 payloads and reports compatibility warnings', () => {
+    const state = createInitialGameState('rome', 202)
+    const legacyPayload = toLegacyPayload(state)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    const migrated = loadStateFromString(legacyPayload)
+
+    expect(migrated.saveVersion).toBe(SAVE_VERSION)
+    expect(Array.from(migrated.diplomacy.wars)).toEqual(Array.from(state.diplomacy.wars))
+    expect(Array.from(migrated.diplomacy.alliances)).toEqual(Array.from(state.diplomacy.alliances))
+    expect(warnSpy).toHaveBeenCalled()
+    expect(
+      warnSpy.mock.calls.some(([message]) => typeof message === 'string' && message.includes('legacy save')),
+    ).toBe(true)
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Save upgraded from v1 to v${SAVE_VERSION}`),
+    )
+  })
+})

--- a/frontend/src/game/data.ts
+++ b/frontend/src/game/data.ts
@@ -7,7 +7,160 @@ import type {
   GameConfig,
   NationState,
   TerritoryState,
+  StatKey,
 } from './types'
+
+const STAT_KEYS: StatKey[] = [
+  'stability',
+  'military',
+  'tech',
+  'economy',
+  'crime',
+  'influence',
+  'support',
+  'science',
+  'laws',
+]
+
+const CONFIG_NUMERIC_KEYS: (keyof Omit<GameConfig, 'combatRandomnessRange'>)[] = [
+  'techGainPerInvest',
+  'scienceGainPerInvest',
+  'economyGainTaxes',
+  'crimeGainTaxes',
+  'lawGainPass',
+  'stabilityGainPass',
+  'spyEffect',
+  'spyCrimeIncrease',
+  'diplomacyEffect',
+  'warStabilityPenalty',
+  'crimeDecay',
+  'stabilityDecayPerWar',
+  'incomePerTerritoryBase',
+  'armyRecruitStrength',
+  'armyMoveCost',
+  'armyUpkeep',
+  'maxActionsPerTurn',
+  'baseSupportDecay',
+  'baseScienceDrift',
+  'baseCrimeGrowth',
+  'eventStabilityVariance',
+  'eventEconomyVariance',
+]
+
+const logWarnings = (context: string, warnings: string[]) => {
+  if (warnings.length > 0) {
+    warnings.forEach((warning) => {
+      console.warn(`[AncientWar2] ${context}: ${warning}`)
+    })
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const assertNationDefinitions = (input: unknown): asserts input is NationDefinition[] => {
+  if (!Array.isArray(input)) {
+    throw new Error('[AncientWar2] nations.json must export an array of nation definitions.')
+  }
+  const warnings: string[] = []
+
+  input.forEach((nation, index) => {
+    if (!isRecord(nation)) {
+      throw new Error(`[AncientWar2] Nation entry at index ${index} is not an object.`)
+    }
+    if (typeof nation.id !== 'string' || nation.id.length === 0) {
+      throw new Error(`[AncientWar2] Nation entry at index ${index} is missing a valid "id" field.`)
+    }
+    if (typeof nation.name !== 'string' || nation.name.length === 0) {
+      warnings.push(`Nation "${nation.id}" is missing a name.`)
+    }
+    if (!Array.isArray(nation.territories)) {
+      warnings.push(`Nation "${nation.id}" territories should be an array; defaulting to empty.`)
+      ;(nation as NationDefinition).territories = []
+    }
+    if (!isRecord(nation.stats)) {
+      throw new Error(`[AncientWar2] Nation "${nation.id}" has an invalid stats block.`)
+    }
+    STAT_KEYS.forEach((key) => {
+      if (typeof (nation.stats as Record<string, unknown>)[key] !== 'number') {
+        warnings.push(`Nation "${nation.id}" stat "${key}" is missing or not numeric.`)
+        ;(nation.stats as Record<string, number>)[key] = 0
+      }
+    })
+    if (!Array.isArray(nation.advantages)) {
+      warnings.push(`Nation "${nation.id}" advantages should be an array; defaulting to empty.`)
+      ;(nation as NationDefinition).advantages = []
+    }
+    if (!Array.isArray(nation.disadvantages)) {
+      warnings.push(`Nation "${nation.id}" disadvantages should be an array; defaulting to empty.`)
+      ;(nation as NationDefinition).disadvantages = []
+    }
+  })
+
+  logWarnings('Nation schema mismatch', warnings)
+}
+
+const assertTerritoryDefinitions = (input: unknown): asserts input is TerritoryDefinition[] => {
+  if (!Array.isArray(input)) {
+    throw new Error('[AncientWar2] territories.json must export an array of territory definitions.')
+  }
+  const warnings: string[] = []
+
+  input.forEach((territory, index) => {
+    if (!isRecord(territory)) {
+      throw new Error(`[AncientWar2] Territory entry at index ${index} is not an object.`)
+    }
+    if (typeof territory.id !== 'string' || territory.id.length === 0) {
+      throw new Error(`[AncientWar2] Territory entry at index ${index} is missing a valid "id" field.`)
+    }
+    if (!Array.isArray(territory.coordinates) || territory.coordinates.length !== 2) {
+      warnings.push(`Territory "${territory.id}" coordinates should be a [x, y] tuple; defaulting to [0, 0].`)
+      ;(territory as TerritoryDefinition).coordinates = [0, 0]
+    } else if (territory.coordinates.some((coord) => typeof coord !== 'number')) {
+      warnings.push(`Territory "${territory.id}" coordinates contained non-numeric values; defaulting to [0, 0].`)
+      ;(territory as TerritoryDefinition).coordinates = [0, 0]
+    }
+    if (!Array.isArray(territory.neighbors)) {
+      warnings.push(`Territory "${territory.id}" neighbors should be an array; defaulting to empty.`)
+      ;(territory as TerritoryDefinition).neighbors = []
+    }
+    if (typeof territory.ownerId !== 'string') {
+      warnings.push(`Territory "${territory.id}" ownerId should be a string; defaulting to empty.`)
+      ;(territory as TerritoryDefinition).ownerId = ''
+    }
+  })
+
+  logWarnings('Territory schema mismatch', warnings)
+}
+
+const assertGameConfig = (input: unknown): asserts input is GameConfig => {
+  if (!isRecord(input)) {
+    throw new Error('[AncientWar2] config.json must export an object.')
+  }
+  const warnings: string[] = []
+
+  if (
+    !Array.isArray(input.combatRandomnessRange) ||
+    input.combatRandomnessRange.length !== 2 ||
+    input.combatRandomnessRange.some((entry: unknown) => typeof entry !== 'number')
+  ) {
+    warnings.push('combatRandomnessRange should be a [min, max] tuple; defaulting to [0.85, 1.15].')
+    ;(input as GameConfig).combatRandomnessRange = [0.85, 1.15]
+  }
+
+  CONFIG_NUMERIC_KEYS.forEach((key) => {
+    if (typeof input[key] !== 'number' || Number.isNaN(input[key])) {
+      warnings.push(`${key} should be a numeric value; defaulting to 0.`)
+      ;(input as GameConfig)[key] = 0 as GameConfig[typeof key]
+    }
+  })
+
+  logWarnings('Config schema mismatch', warnings)
+}
+
+assertNationDefinitions(nationsRaw)
+assertTerritoryDefinitions(territoriesRaw)
+assertGameConfig(configRaw)
 
 export const nations: NationDefinition[] = nationsRaw
 export const territories: TerritoryDefinition[] = territoriesRaw

--- a/frontend/src/game/engine.ts
+++ b/frontend/src/game/engine.ts
@@ -1,4 +1,5 @@
 import { nations, territories, gameConfig, buildInitialNationState, buildInitialTerritoryState } from './data'
+import { SAVE_VERSION } from './save'
 import { RandomGenerator } from './random'
 import { TERRAIN_MODIFIERS } from './constants'
 import type {
@@ -72,6 +73,7 @@ export const createInitialGameState = (
   })
 
   const state: GameState = {
+    saveVersion: SAVE_VERSION,
     turn: 1,
     currentPhase: 'player',
     playerNationId,
@@ -591,26 +593,4 @@ export const executePlayerAction = (
   return false
 }
 
-export const quickSaveState = (state: GameState): string => {
-  const serialisable = {
-    ...state,
-    diplomacy: {
-      ...state.diplomacy,
-      wars: Array.from(state.diplomacy.wars),
-      alliances: Array.from(state.diplomacy.alliances),
-    },
-  }
-  return JSON.stringify(serialisable)
-}
-
-export const loadStateFromString = (payload: string): GameState => {
-  const parsed = JSON.parse(payload)
-  return {
-    ...parsed,
-    diplomacy: {
-      relations: parsed.diplomacy.relations,
-      wars: new Set(parsed.diplomacy.wars),
-      alliances: new Set(parsed.diplomacy.alliances),
-    },
-  }
-}
+export { quickSaveState, loadStateFromString, SAVE_VERSION } from './save'

--- a/frontend/src/game/save.ts
+++ b/frontend/src/game/save.ts
@@ -1,0 +1,234 @@
+import type {
+  GameState,
+  NotificationEntry,
+  PlayerAction,
+  TurnLogEntry,
+  NationState,
+  TerritoryState,
+} from './types'
+
+export const SAVE_VERSION = 2
+const LEGACY_VERSION = 1
+
+interface SerializedDiplomacy {
+  relations: GameState['diplomacy']['relations']
+  wars: string[]
+  alliances: string[]
+}
+
+interface SerializedGameState {
+  turn: number
+  currentPhase: GameState['currentPhase']
+  playerNationId: string
+  nations: Record<string, NationState>
+  territories: Record<string, TerritoryState>
+  diplomacy: SerializedDiplomacy
+  selectedTerritoryId?: string
+  pendingAction?: PlayerAction
+  log: TurnLogEntry[]
+  notifications: NotificationEntry[]
+  queuedEvents: string[]
+  winner?: string
+  defeated?: boolean
+  actionsTaken: number
+  saveVersion?: number
+}
+
+interface MigrationResult {
+  state: GameState
+  warnings: string[]
+  migratedFrom: number | null
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const toNumber = (value: unknown, fallback: number, field: string, warnings: string[]): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  warnings.push(`Field "${field}" was invalid; defaulting to ${fallback}.`)
+  return fallback
+}
+
+const toStringField = (value: unknown, fallback: string, field: string, warnings: string[]): string => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value
+  }
+  warnings.push(`Field "${field}" was invalid; defaulting to "${fallback}".`)
+  return fallback
+}
+
+const toOptionalString = (
+  value: unknown,
+): string | undefined => (typeof value === 'string' && value.length > 0 ? value : undefined)
+
+const toBoolean = (value: unknown, fallback: boolean, field: string, warnings: string[]): boolean => {
+  if (typeof value === 'boolean') {
+    return value
+  }
+  warnings.push(`Field "${field}" was invalid; defaulting to ${fallback}.`)
+  return fallback
+}
+
+const toStringArray = (value: unknown, field: string, warnings: string[]): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string')
+  }
+  warnings.push(`Field "${field}" was invalid; defaulting to an empty list.`)
+  return []
+}
+
+const toRecord = <T extends Record<string, unknown>>(
+  value: unknown,
+  field: string,
+  warnings: string[],
+  fallback: T,
+): T => {
+  if (isRecord(value)) {
+    return value as T
+  }
+  warnings.push(`Field "${field}" was invalid; defaulting to an empty record.`)
+  return fallback
+}
+
+const toArray = <T>(value: unknown, field: string, warnings: string[]): T[] => {
+  if (Array.isArray(value)) {
+    return value as T[]
+  }
+  warnings.push(`Field "${field}" was invalid; defaulting to an empty list.`)
+  return []
+}
+
+const VALID_PHASES: GameState['currentPhase'][] = ['selection', 'player', 'ai', 'events', 'gameover']
+
+const toPhase = (
+  value: unknown,
+  fallback: GameState['currentPhase'],
+  warnings: string[],
+): GameState['currentPhase'] => {
+  if (typeof value === 'string' && (VALID_PHASES as string[]).includes(value)) {
+    return value as GameState['currentPhase']
+  }
+  warnings.push(`Field "currentPhase" was invalid; defaulting to "${fallback}".`)
+  return fallback
+}
+
+const normalise = (raw: SerializedGameState): MigrationResult => {
+  const warnings: string[] = []
+
+  const turn = toNumber(raw.turn, 1, 'turn', warnings)
+  const currentPhase = toPhase(raw.currentPhase, 'player', warnings)
+  const playerNationId = toStringField(raw.playerNationId, 'rome', 'playerNationId', warnings)
+  const nations = toRecord(raw.nations, 'nations', warnings, {})
+  const territories = toRecord(raw.territories, 'territories', warnings, {})
+
+  const diplomacyRaw = toRecord(raw.diplomacy, 'diplomacy', warnings, {
+    relations: {},
+    wars: [],
+    alliances: [],
+  })
+  const relations = toRecord(
+    diplomacyRaw.relations,
+    'diplomacy.relations',
+    warnings,
+    {},
+  )
+  const wars = toStringArray(diplomacyRaw.wars, 'diplomacy.wars', warnings)
+  const alliances = toStringArray(diplomacyRaw.alliances, 'diplomacy.alliances', warnings)
+
+  const log = toArray<TurnLogEntry>(raw.log, 'log', warnings)
+  const notifications = toArray<NotificationEntry>(raw.notifications, 'notifications', warnings)
+  const queuedEvents = toStringArray(raw.queuedEvents, 'queuedEvents', warnings)
+  const pendingAction = isRecord(raw.pendingAction) ? (raw.pendingAction as PlayerAction) : undefined
+  const winner = toOptionalString(raw.winner)
+  const defeated = raw.defeated !== undefined ? toBoolean(raw.defeated, false, 'defeated', warnings) : undefined
+  const actionsTaken = toNumber(raw.actionsTaken, 0, 'actionsTaken', warnings)
+
+  const state: GameState = {
+    saveVersion: SAVE_VERSION,
+    turn,
+    currentPhase,
+    playerNationId,
+    nations,
+    territories,
+    diplomacy: {
+      relations,
+      wars: new Set(wars),
+      alliances: new Set(alliances),
+    },
+    selectedTerritoryId: toOptionalString(raw.selectedTerritoryId),
+    pendingAction,
+    log,
+    notifications,
+    queuedEvents,
+    winner,
+    defeated,
+    actionsTaken,
+  }
+
+  const migratedFrom = typeof raw.saveVersion === 'number' ? raw.saveVersion : null
+
+  return { state, warnings, migratedFrom }
+}
+
+const applyMigrations = (raw: unknown): MigrationResult => {
+  if (!isRecord(raw)) {
+    throw new Error('Save payload was not a valid object.')
+  }
+
+  const version = typeof raw.saveVersion === 'number' ? raw.saveVersion : LEGACY_VERSION
+  const result = normalise(raw as SerializedGameState)
+
+  if (version > SAVE_VERSION) {
+    result.warnings.unshift(
+      `Save version v${version} is newer than supported v${SAVE_VERSION}; attempting best-effort load.`,
+    )
+  }
+  if (version < SAVE_VERSION) {
+    result.warnings.unshift(
+      `Loaded legacy save v${version}; applied default values introduced in v${SAVE_VERSION}.`,
+    )
+  }
+
+  if (version < SAVE_VERSION) {
+    result.migratedFrom = version
+  }
+
+  return result
+}
+
+export const quickSaveState = (state: GameState): string => {
+  const serialisable: SerializedGameState & { saveVersion: number } = {
+    ...state,
+    saveVersion: SAVE_VERSION,
+    diplomacy: {
+      relations: state.diplomacy.relations,
+      wars: Array.from(state.diplomacy.wars),
+      alliances: Array.from(state.diplomacy.alliances),
+    },
+  }
+  return JSON.stringify(serialisable)
+}
+
+export const loadStateFromString = (payload: string): GameState => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(payload)
+  } catch (error) {
+    throw new Error('Failed to parse save payload: invalid JSON.')
+  }
+
+  const { state, warnings, migratedFrom } = applyMigrations(parsed)
+  warnings.forEach((warning) => {
+    console.warn(`[AncientWar2] ${warning}`)
+  })
+
+  if (migratedFrom !== null && migratedFrom < SAVE_VERSION) {
+    console.info(
+      `[AncientWar2] Save upgraded from v${migratedFrom} to v${SAVE_VERSION}; future saves will persist the new schema.`,
+    )
+  }
+
+  return state
+}

--- a/frontend/src/game/types.ts
+++ b/frontend/src/game/types.ts
@@ -119,6 +119,7 @@ export interface GameConfig {
 }
 
 export interface GameState {
+  saveVersion: number
   turn: number
   currentPhase: 'selection' | 'player' | 'ai' | 'events' | 'gameover'
   playerNationId: string


### PR DESCRIPTION
## Summary
- add a dedicated save module that embeds a saveVersion, migrates legacy payloads, and surfaces compatibility logs
- validate imported nation, territory, and config JSON files with schema checks and document the migration behaviour in the README
- cover the migration flow with a new Vitest suite to guarantee v1 saves load cleanly

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dfda46dc848322a3582574f9ff5096